### PR TITLE
change example template sensor format in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ automation:
         data:
           variable: test_timer
           value: >
-            {{ [((states.variable.test_timer.state | int) - 1), 0] | max }}
+            {{ [((states('variable.test_timer') | int) - 1), 0] | max }}
 
   - alias: test_timer_trigger
     trigger:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ automation:
         data:
           variable: test_timer
           value: >
-            {{ [((states('variable.test_timer') | int) - 1), 0] | max }}
+            {{ [((states('variable.test_timer') | int(default=0)) - 1), 0] | max }}
 
   - alias: test_timer_trigger
     trigger:


### PR DESCRIPTION
which is preferred method to prevent startup issues.

you might also weans to check adding a default value to the ```|int```