### PR TITLE
Support for custom domain

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -1,0 +1,20 @@
+#Limited configuration instead of default_config
+#https://github.com/home-assistant/core/tree/dev/homeassistant/components/default_config
+automation:
+frontend:
+history:
+logbook:
+
+homeassistant:
+  name: Home
+
+variable:
+  test_counter:
+    value: 0
+    attributes:
+      icon: mdi:alarm
+
+logger:
+  default: info
+  logs:
+    custom_components.variable: debug

--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -9,6 +9,11 @@ homeassistant:
   name: Home
 
 variable:
+  test_sensor:
+    value: 0
+    restore: true
+    domain: sensor
+
   test_counter:
     value: 0
     attributes:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+	"name": "Home Assistant Custom Component Dev",
+	"context": "..",
+	"image": "ghcr.io/ludeeus/devcontainer/integration:latest",
+	"appPort": "9123:8123",
+	"postCreateCommand": "container install && pip install --upgrade pip && pip install --ignore-installed -r requirements.txt",
+	"extensions": [
+		"ms-python.python",
+		"github.vscode-pull-request-github",
+		"ms-python.vscode-pylance",
+		"spmeesseman.vscode-taskexplorer"
+	],
+	"settings": {
+		"files.eol": "\n",
+		"editor.tabSize": 4,
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"python.pythonPath": "/usr/local/python/bin/python",
+		"python.analysis.autoSearchPaths": false,
+		"python.linting.pylintEnabled": true,
+		"python.linting.enabled": true,
+		"python.linting.pylintArgs": [
+			"--disable",
+			"import-error"
+		],
+		"python.formatting.provider": "black",
+		"python.testing.pytestArgs": [
+			"--no-cov"
+		],
+		"editor.formatOnPaste": false,
+		"editor.formatOnSave": true,
+		"editor.formatOnType": true,
+		"files.trimTrailingWhitespace": true
+	}
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+*     text eol=lf
+*.py  whitespace=error
+
+*.ico binary
+*.jpg binary
+*.png binary
+*.zip binary
+*.mp3 binary

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.formatting.provider": "black",
+    "editor.formatOnPaste": true,
+    "editor.formatOnSave": true,
+    "files.trimTrailingWhitespace": true,
+    "git.ignoreLimitWarning": true,
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Home Assistant on port 9123",
+            "type": "shell",
+            "command": "container start",
+            "problemMatcher": []
+        },
+        {
+            "label": "Run Home Assistant configuration against /config",
+            "type": "shell",
+            "command": "container check",
+            "problemMatcher": []
+        },
+        {
+            "label": "Upgrade Home Assistant to latest dev",
+            "type": "shell",
+            "command": "container install",
+            "problemMatcher": []
+        },
+        {
+            "label": "Install a specific version of Home Assistant",
+            "type": "shell",
+            "command": "container set-version",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -42,9 +42,20 @@ variable:
     restore: true
   current_power_usage:
     force_update: true
+
+  daily_download:
+    value: 0
+    restore: true
+    domain: sensor
+    attributes:
+      state_class: measurement
+      unit_of_measurement: GB
+      icon: mdi:download
 ```
 
 A variable 'should' have a __value__ and can optionally have a __name__ and __attributes__, which can be used to specify additional values but can also be used to set internal attributes like icon, friendly_name etc.
+
+A variable can accept an optional `domain` which results in the entity name to start with that domain instead of `variable`.
 
 In case you want your variable to restore its value and attributes after restarting you can set __restore__ to true.
 
@@ -52,9 +63,11 @@ In case you want your variable to update (and add a history entry) even if the v
 
 ## Set variables from automations
 
-To update a variables value and/or its attributes you can use the service call `variable.set_variable`
+The variable componet exposes 2 services:
+* `variable.set_variable` can be used to update a variables value and/or its attributes.
+* `variable.set_entity` can be used to update an entity value and/or its attributes.
 
-The following parameters can be used with this service:
+The following parameters can be used with `variable.set_variable`:
 
 - __variable: string (required)__
 The name of the variable to update
@@ -65,7 +78,19 @@ Attributes to set or update
 - __replace_attributes: boolean ( optional )__
 Replace or merge current attributes (default false = merge)
 
-### Example service calls
+
+The following parameters can be used with `variable.set_entity`:
+
+- __entity: string (required)__
+The id of the entity to update
+- __value: any (optional)__
+New value to set
+- __attributes: dictionary (optional)__
+Attributes to set or update
+- __replace_attributes: boolean ( optional )__
+Replace or merge current attributes (default false = merge)
+
+#### Example service calls
 
 ```yaml
 action:
@@ -83,6 +108,12 @@ action:
           history_1: "{{states('variable.last_motion')}}"
           history_2: "{{state_attr('variable.last_motion','history_1')}}"
           history_3: "{{state_attr('variable.last_motion','history_2')}}"
+
+action:
+  - service: variable.set_entity
+    data:
+      variable: sensor.test_counter
+      value: 30
 ```
 
 ### Example timer automation

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In case you want your variable to update (and add a history entry) even if the v
 
 ## Set variables from automations
 
-The variable componet exposes 2 services:
+The variable component exposes 2 services:
 * `variable.set_variable` can be used to update a variables value and/or its attributes.
 * `variable.set_entity` can be used to update an entity value and/or its attributes.
 

--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,0 +1,1 @@
+"""Dummy __init__.py to make imports with homeassistant-custom-component work."""

--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -108,7 +108,7 @@ async def async_setup(hass, config):
                 call.data.get(ATTR_REPLACE_ATTRIBUTES, False),
             )
         else:
-            _LOGGER.warning(f"Failed to set unknown variable: {entity_id}")
+            _LOGGER.warning("Failed to set unknown variable: %s", entity_id)
 
     hass.services.async_register(
         DOMAIN,
@@ -174,7 +174,7 @@ class Variable(RestoreEntity):
 
     @property
     def force_update(self) -> bool:
-        """Force update"""
+        """Force an update."""
         return self._force_update
 
     async def async_set_variable(
@@ -184,7 +184,6 @@ class Variable(RestoreEntity):
         replace_attributes,
     ):
         """Update variable."""
-        current_state = self.hass.states.get(self.entity_id)
         updated_attributes = None
         updated_value = None
 

--- a/custom_components/variable/services.yaml
+++ b/custom_components/variable/services.yaml
@@ -8,9 +8,25 @@ set_variable:
     # Key of the field
     variable:
       description: string (required) The name of the variable to update
+      example: test_counter
     value:
       description: any (optional) New value to set
+      example: 9
     attributes:
       description: dictionary (optional) Attributes to set or update
     replace_attributes:
-      description: boolean ( optional ) Replace or merge current attributes (default false = merge)
+      description: boolean (optional) Replace or merge current attributes (default false = merge)
+
+set_entity:
+  description: Update an entity value and/or its attributes.
+  fields:
+    entity:
+      description: string (required) The id of the entity to update
+      example: sensor.test_sensor
+    value:
+      description: any (optional) New value to set
+      example: 9
+    attributes:
+      description: dictionary (optional) Attributes to set or update
+    replace_attributes:
+      description: boolean (optional) Replace or merge current attributes (default false = merge)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Custom requirements
 
 # Pre-commit requirements
+codespell==2.1.0
 flake8-comprehensions==3.8.0
 flake8-docstrings==1.6.0
 flake8-noqa==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,13 @@
 # Custom requirements
 
 # Pre-commit requirements
-bandit==1.7.4
-black==22.6.0
-codespell==2.1.0
 flake8-comprehensions==3.8.0
 flake8-docstrings==1.6.0
 flake8-noqa==1.2.1
 flake8==4.0.1
 isort==5.10.1
-mccabe==0.6.1
-pycodestyle==2.8.0
-pydocstyle==6.1.1
-pyflakes==2.4.0
-pyupgrade==2.34.0
-yamllint==1.26.3
-
 
 # Unit tests requirements
-pre-commit==2.19.0
-pylint==2.14.4
 pytest==7.1.2
 pytest-cov==3.0.0
 pytest-homeassistant-custom-component

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,25 @@
+# Custom requirements
+
+# Pre-commit requirements
+bandit==1.7.4
+black==22.6.0
+codespell==2.1.0
+flake8-comprehensions==3.8.0
+flake8-docstrings==1.6.0
+flake8-noqa==1.2.1
+flake8==4.0.1
+isort==5.10.1
+mccabe==0.6.1
+pycodestyle==2.8.0
+pydocstyle==6.1.1
+pyflakes==2.4.0
+pyupgrade==2.34.0
+yamllint==1.26.3
+
+
+# Unit tests requirements
+pre-commit==2.19.0
+pylint==2.14.4
+pytest==7.1.2
+pytest-cov==3.0.0
+pytest-homeassistant-custom-component

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,41 @@
+[tool:pytest]
+testpaths = tests
+norecursedirs = .git
+addopts =
+    --strict
+    --cov=custom_components
+
+[flake8]
+exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
+doctests = True
+# To work with Black
+# E501: line too long
+# W503: Line break occurred before a binary operator
+# E203: Whitespace before ':'
+# D202 No blank lines allowed after function docstring
+# W504 line break after binary operator
+ignore =
+    E501,
+    W503,
+    E203,
+    D202,
+    W504
+noqa-require-code = True
+
+[isort]
+# https://github.com/timothycrosley/isort
+# https://github.com/timothycrosley/isort/wiki/isort-Settings
+# splits long import on multiple lines indented by 4 spaces
+multi_line_output = 3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
+indent = "    "
+# will group `import x` and `from x import` of the same module.
+force_sort_within_sections = true
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+default_section = THIRDPARTY
+known_first_party = custom_components,tests
+forced_separate = tests
+combine_as_imports = true


### PR DESCRIPTION
This pull allow an alternate domain e.g. sensor to be defined. It also includes a new service which can update any entity.

* I also took the liberty to define devcontainer, etc. for development so one can run flake8, isort from terminal.
* Deleted unused code/imports , `set_variable` function was not being used.

I am a little unsure about the new service since it can update any entity. I originally created it for updating entities other than variable but it seems that it can update/create any entity.

#17 