### PR TITLE
Prevent AttributeError in Service Call

### DIFF
--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -136,9 +136,7 @@ class Variable(BinarySensorEntity, RestoreEntity):
             _LOGGER.info(f"({self._attr_name}) Restoring after Reboot")
             state = await self.async_get_last_state()
             if state:
-                _LOGGER.debug(
-                    f"({self._attr_name}) Restored state: {state.as_dict()}"
-                )
+                _LOGGER.debug(f"({self._attr_name}) Restored state: {state.as_dict()}")
                 self._attr_extra_state_attributes = state.attributes
                 if state.state == STATE_OFF:
                     self._attr_is_on = False
@@ -171,7 +169,11 @@ class Variable(BinarySensorEntity, RestoreEntity):
         updated_attributes = None
         updated_value = None
 
-        if not replace_attributes and self._attr_extra_state_attributes is not None:
+        if (
+            not replace_attributes
+            and hasattr(self, "_attr_extra_state_attributes")
+            and self._attr_extra_state_attributes is not None
+        ):
             updated_attributes = dict(self._attr_extra_state_attributes)
 
         if attributes is not None:

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -142,11 +142,12 @@ class Variable(RestoreSensor):
                 # Unsure how to deal with state vs native_value on restore.
                 # Setting Restored state to override native_value for now.
                 # self._state = state.state
-                if (sensor is None or (
-                    sensor and state.state is not None
+                if sensor is None or (
+                    sensor
+                    and state.state is not None
                     and state.state.lower() != "none"
                     and sensor.native_value != state.state
-                )):
+                ):
                     _LOGGER.info(
                         f"({self._attr_name}) Restored values are different. "
                         f"native_value: {sensor.native_value} | state: {state.state}"
@@ -174,7 +175,11 @@ class Variable(RestoreSensor):
         updated_attributes = None
         updated_value = None
 
-        if not replace_attributes and self._attr_extra_state_attributes is not None:
+        if (
+            not replace_attributes
+            and hasattr(self, "_attr_extra_state_attributes")
+            and self._attr_extra_state_attributes is not None
+        ):
             updated_attributes = dict(self._attr_extra_state_attributes)
 
         if attributes is not None:


### PR DESCRIPTION
If Attributes was never initially set and then it is set in the Service Call (and replace_attributes is false), it would generate the AttributeError.