### PR TITLE
Add option to exclude from recorder

### DIFF
--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -2,12 +2,18 @@
 import json
 import logging
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_FRIENDLY_NAME, CONF_ICON, CONF_NAME, Platform
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT
+from homeassistant.const import (
+    CONF_FRIENDLY_NAME,
+    CONF_ICON,
+    CONF_NAME,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.typing import ConfigType
-import voluptuous as vol
 
 from .const import (
     ATTR_ATTRIBUTES,
@@ -27,6 +33,15 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+try:
+    USE_ISSUE_REG = True
+    from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+except ImportError as e:
+    _LOGGER.debug(
+        f"Unknown Exception trying to import issue_registry. Is HA version <2022.9?: {e}"
+    )
+    USE_ISSUE_REG = False
 
 SERVICE_SET_VARIABLE_LEGACY = "set_variable"
 SERVICE_SET_ENTITY_LEGACY = "set_entity"
@@ -56,6 +71,8 @@ SERVICE_SET_ENTITY_LEGACY_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistant, config: ConfigType):
     """Set up the Variable services."""
+    # _LOGGER.debug("Starting async_setup")
+    # _LOGGER.debug("[async_setup] config: " + str(config))
 
     async def async_set_variable_legacy_service(call):
         """Handle calls to the set_variable legacy service."""
@@ -133,7 +150,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
                     new_attr = pre_attr
             else:
                 new_attr = call.data.get(ATTR_ATTRIBUTES)
-            _LOGGER.debug(f"[async_set_entity_legacy_service] Updated attr: {new_attr}")
+            _LOGGER.debug(
+                f"[async_set_entity_legacy_service] Updated attr: {new_attr}"
+            )
             hass.states.async_set(
                 entity_id=entity_id,
                 new_state=call.data.get(ATTR_VALUE),
@@ -164,13 +183,25 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
 
     variables = json.loads(json.dumps(config.get(DOMAIN, {})))
 
+    if variables and USE_ISSUE_REG:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "restart_required_variable",
+            is_fixable=True,
+            severity=IssueSeverity.WARNING,
+            translation_key="restart_required_variable",
+        )
+
     for var, var_fields in variables.items():
+        if var is not None and var not in {
+            entry.data.get(CONF_VARIABLE_ID)
+            for entry in hass.config_entries.async_entries(DOMAIN)
+        }:
+            _LOGGER.warning(f"[YAML Import] New YAML sensor, importing: {var}")
+            _LOGGER.debug(f"[YAML Import] var_fields: {var_fields}")
 
-        if var is not None:
-            _LOGGER.debug(f"[YAML] variable_id: {var}")
-            _LOGGER.debug(f"[YAML] var_fields: {var_fields}")
-
-            for key_empty, var_empty in var_fields.copy().items():
+            for key_empty, var_empty in var_fields.items():
                 if var_empty is None:
                     var_fields.pop(key_empty)
 
@@ -179,54 +210,24 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
             name = var_fields.get(CONF_NAME, attr.pop(CONF_FRIENDLY_NAME, None))
             attr.pop(CONF_FRIENDLY_NAME, None)
 
-            if var not in {
-                entry.data.get(CONF_VARIABLE_ID)
-                for entry in hass.config_entries.async_entries(DOMAIN)
-            }:
-                _LOGGER.warning(f"[YAML Import] Creating New Sensor Variable: {var}")
-                hass.async_create_task(
-                    hass.config_entries.flow.async_init(
-                        DOMAIN,
-                        context={"source": SOURCE_IMPORT},
-                        data={
-                            CONF_ENTITY_PLATFORM: Platform.SENSOR,
-                            CONF_VARIABLE_ID: var,
-                            CONF_NAME: name,
-                            CONF_VALUE: var_fields.get(CONF_VALUE),
-                            CONF_RESTORE: var_fields.get(CONF_RESTORE),
-                            CONF_FORCE_UPDATE: var_fields.get(CONF_FORCE_UPDATE),
-                            CONF_ATTRIBUTES: attr,
-                            CONF_ICON: icon,
-                        },
-                    )
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": SOURCE_IMPORT},
+                    data={
+                        CONF_ENTITY_PLATFORM: Platform.SENSOR,
+                        CONF_VARIABLE_ID: var,
+                        CONF_NAME: name,
+                        CONF_VALUE: var_fields.get(CONF_VALUE),
+                        CONF_RESTORE: var_fields.get(CONF_RESTORE),
+                        CONF_FORCE_UPDATE: var_fields.get(CONF_FORCE_UPDATE),
+                        CONF_ATTRIBUTES: attr,
+                        CONF_ICON: icon,
+                    },
                 )
-            else:
-                _LOGGER.info(f"[YAML Update] Updating Existing Sensor Variable: {var}")
-
-                entry_id = None
-                for ent in hass.config_entries.async_entries(DOMAIN):
-                    if var == ent.data.get(CONF_VARIABLE_ID):
-                        entry_id = ent.entry_id
-                        break
-                _LOGGER.debug(f"[YAML Update] entry_id: {entry_id}")
-                if entry_id:
-                    entry = ent
-                    _LOGGER.debug(f"[YAML Update] entry before: {entry.as_dict()}")
-
-                    for m in dict(entry.data).keys():
-                        var_fields.setdefault(m, entry.data[m])
-                    _LOGGER.debug(f"[YAML Update] updated var_fields: {var_fields}")
-                    entry.options = {}
-                    hass.config_entries.async_update_entry(
-                        entry, data=var_fields, options=entry.options
-                    )
-
-                    hass.config_entries.async_reload(entry_id)
-
-                else:
-                    _LOGGER.error(
-                        f"YAML Update Error. Could not find entry_id for: {var}"
-                    )
+            )
+        else:
+            _LOGGER.info(f"[YAML Import] Already Imported: {var}")
 
     return True
 
@@ -251,7 +252,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     _LOGGER.info(f"Unloading: {entry.data}")
     hass_data = dict(entry.data)
-    unload_ok = False
     if hass_data.get(CONF_ENTITY_PLATFORM) in PLATFORMS:
         unload_ok = await hass.config_entries.async_unload_platforms(
             entry, [hass_data.get(CONF_ENTITY_PLATFORM)]

--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -19,7 +19,6 @@ from .const import (
     CONF_RESTORE,
     CONF_VALUE,
     CONF_VARIABLE_ID,
-    CONF_YAML_VARIABLE,
     DEFAULT_FORCE_UPDATE,
     DEFAULT_ICON,
     DEFAULT_REPLACE_ATTRIBUTES,
@@ -117,10 +116,18 @@ class Variable(BinarySensorEntity, RestoreEntity):
         self._attr_extra_state_attributes = config.get(CONF_ATTRIBUTES)
         self._restore = config.get(CONF_RESTORE)
         self._force_update = config.get(CONF_FORCE_UPDATE)
-        self._yaml_variable = config.get(CONF_YAML_VARIABLE)
         self.entity_id = generate_entity_id(
             ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
         )
+        # _LOGGER.debug(f"[init] name: {self._attr_name}")
+        # _LOGGER.debug(f"[init] variable_id: {self._variable_id}")
+        # _LOGGER.debug(f"[init] entity_id: {self.entity_id}")
+        # _LOGGER.debug(f"[init] unique_id: {self._attr_unique_id}")
+        # _LOGGER.debug(f"[init] icon: {self._attr_icon}")
+        # _LOGGER.debug(f"[init] value: {self._attr_is_on}")
+        # _LOGGER.debug(f"[init] attributes: {self._attr_extra_state_attributes}")
+        # _LOGGER.debug(f"[init] restore: {self._restore}")
+        # _LOGGER.debug(f"[init] force_update: {self._force_update}")
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""
@@ -129,7 +136,9 @@ class Variable(BinarySensorEntity, RestoreEntity):
             _LOGGER.info(f"({self._attr_name}) Restoring after Reboot")
             state = await self.async_get_last_state()
             if state:
-                _LOGGER.debug(f"({self._attr_name}) Restored state: {state.as_dict()}")
+                _LOGGER.debug(
+                    f"({self._attr_name}) Restored state: {state.as_dict()}"
+                )
                 self._attr_extra_state_attributes = state.attributes
                 if state.state == STATE_OFF:
                     self._attr_is_on = False
@@ -162,11 +171,7 @@ class Variable(BinarySensorEntity, RestoreEntity):
         updated_attributes = None
         updated_value = None
 
-        if (
-            not replace_attributes
-            and hasattr(self, "_attr_extra_state_attributes")
-            and self._attr_extra_state_attributes is not None
-        ):
+        if not replace_attributes and self._attr_extra_state_attributes is not None:
             updated_attributes = dict(self._attr_extra_state_attributes)
 
         if attributes is not None:

--- a/custom_components/variable/config_flow.py
+++ b/custom_components/variable/config_flow.py
@@ -14,10 +14,12 @@ import voluptuous as vol
 from .const import (
     CONF_ATTRIBUTES,
     CONF_ENTITY_PLATFORM,
+    CONF_EXCLUDE_FROM_RECORDER,
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
     CONF_VALUE,
     CONF_VARIABLE_ID,
+    DEFAULT_EXCLUDE_FROM_RECORDER,
     DEFAULT_FORCE_UPDATE,
     DEFAULT_ICON,
     DEFAULT_RESTORE,
@@ -50,6 +52,9 @@ ADD_SENSOR_SCHEMA = vol.Schema(
         vol.Optional(
             CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE
         ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+        vol.Optional(
+            CONF_EXCLUDE_FROM_RECORDER, default=DEFAULT_EXCLUDE_FROM_RECORDER
+        ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
     }
 )
 
@@ -77,6 +82,9 @@ ADD_BINARY_SENSOR_SCHEMA = vol.Schema(
         ),
         vol.Optional(
             CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE
+        ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+        vol.Optional(
+            CONF_EXCLUDE_FROM_RECORDER, default=DEFAULT_EXCLUDE_FROM_RECORDER
         ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
     }
 )
@@ -239,6 +247,12 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_FORCE_UPDATE, DEFAULT_FORCE_UPDATE
                     ),
                 ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+                vol.Optional(
+                    CONF_EXCLUDE_FROM_RECORDER,
+                    default=self.config_entry.data.get(
+                        CONF_EXCLUDE_FROM_RECORDER, DEFAULT_EXCLUDE_FROM_RECORDER
+                    ),
+                ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
             }
         )
 
@@ -286,6 +300,12 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_FORCE_UPDATE,
                     default=self.config_entry.data.get(
                         CONF_FORCE_UPDATE, DEFAULT_FORCE_UPDATE
+                    ),
+                ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+                vol.Optional(
+                    CONF_EXCLUDE_FROM_RECORDER,
+                    default=self.config_entry.data.get(
+                        CONF_EXCLUDE_FROM_RECORDER, DEFAULT_EXCLUDE_FROM_RECORDER
                     ),
                 ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
             }

--- a/custom_components/variable/const.py
+++ b/custom_components/variable/const.py
@@ -9,6 +9,7 @@ DEFAULT_FORCE_UPDATE = False
 DEFAULT_ICON = "mdi:variable"
 DEFAULT_REPLACE_ATTRIBUTES = False
 DEFAULT_RESTORE = True
+DEFAULT_EXCLUDE_FROM_RECORDER = False
 
 CONF_ATTRIBUTES = "attributes"
 CONF_ENTITY_PLATFORM = "entity_platform"
@@ -16,6 +17,7 @@ CONF_FORCE_UPDATE = "force_update"
 CONF_RESTORE = "restore"
 CONF_VALUE = "value"
 CONF_VARIABLE_ID = "variable_id"
+CONF_EXCLUDE_FROM_RECORDER = "exclude_from_recorder"
 
 ATTR_ATTRIBUTES = "attributes"
 ATTR_ENTITY = "entity"

--- a/custom_components/variable/const.py
+++ b/custom_components/variable/const.py
@@ -16,7 +16,6 @@ CONF_FORCE_UPDATE = "force_update"
 CONF_RESTORE = "restore"
 CONF_VALUE = "value"
 CONF_VARIABLE_ID = "variable_id"
-CONF_YAML_VARIABLE = "yaml_variable"
 
 ATTR_ATTRIBUTES = "attributes"
 ATTR_ENTITY = "entity"

--- a/custom_components/variable/manifest.json
+++ b/custom_components/variable/manifest.json
@@ -1,6 +1,7 @@
 {
     "domain": "variable",
     "name": "Variables+History",
+    "after_dependencies": ["recorder"],
     "codeowners": [
         "@rogro82",
         "@wibias",

--- a/custom_components/variable/manifest.json
+++ b/custom_components/variable/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/Wibias/hass-variables/issues",
     "requirements": [],
-    "version": "3.1.0"
+    "version": "3.0.1"
 }

--- a/custom_components/variable/repairs.py
+++ b/custom_components/variable/repairs.py
@@ -1,0 +1,58 @@
+"""Repairs platform to Restart HA"""
+
+# Adopted from HACS repairs.py
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+import voluptuous as vol
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class RestartRequiredFixFlow(RepairsFlow):
+    """Handler for an issue fixing flow."""
+
+    def __init__(self, issue_id: str) -> None:
+        self.issue_id = issue_id
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+
+        return await self.async_step_confirm_restart()
+
+    async def async_step_confirm_restart(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        if user_input is not None:
+            _LOGGER.debug(f"[async_step_confirm_restart] user_input: {user_input}")
+            await self.hass.services.async_call("homeassistant", "restart")
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(
+            step_id="confirm_restart",
+            data_schema=vol.Schema({}),
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    *args: Any,
+    data: dict[str, str | int | float | None] | None = None,
+    **kwargs: Any,
+) -> RepairsFlow | None:
+    """Create flow."""
+    _LOGGER.debug(f"[async_create_fix_flow] issue_id: {issue_id}")
+    _LOGGER.debug(f"[async_create_fix_flow] data: {data}")
+    if issue_id.startswith("restart_required"):
+        return RestartRequiredFixFlow(issue_id)
+    return None

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -1,5 +1,6 @@
 import logging
 
+from homeassistant.components.recorder import DATA_INSTANCE as RECORDER_INSTANCE
 from homeassistant.components.sensor import PLATFORM_SCHEMA, RestoreSensor
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ICON, CONF_NAME, Platform
@@ -14,10 +15,12 @@ from .const import (
     ATTR_REPLACE_ATTRIBUTES,
     ATTR_VALUE,
     CONF_ATTRIBUTES,
+    CONF_EXCLUDE_FROM_RECORDER,
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
     CONF_VALUE,
     CONF_VARIABLE_ID,
+    DEFAULT_EXCLUDE_FROM_RECORDER,
     DEFAULT_FORCE_UPDATE,
     DEFAULT_ICON,
     DEFAULT_REPLACE_ATTRIBUTES,
@@ -39,6 +42,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_ATTRIBUTES): dict,
         vol.Optional(CONF_RESTORE, default=DEFAULT_RESTORE): cv.boolean,
         vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
+        vol.Optional(
+            CONF_EXCLUDE_FROM_RECORDER, default=DEFAULT_EXCLUDE_FROM_RECORDER
+        ): cv.boolean,
     }
 )
 
@@ -110,9 +116,12 @@ class Variable(RestoreSensor):
             self._attr_extra_state_attributes = config.get(CONF_ATTRIBUTES)
         self._restore = config.get(CONF_RESTORE)
         self._force_update = config.get(CONF_FORCE_UPDATE)
+        self._exclude_from_recorder = config.get(CONF_EXCLUDE_FROM_RECORDER)
         self.entity_id = generate_entity_id(
             ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
         )
+        if self._exclude_from_recorder:
+            self.disable_recorder()
         # _LOGGER.debug(f"[init] name: {self._attr_name}")
         # _LOGGER.debug(f"[init] variable_id: {self._variable_id}")
         # _LOGGER.debug(f"[init] entity_id: {self.entity_id}")
@@ -122,6 +131,17 @@ class Variable(RestoreSensor):
         # _LOGGER.debug(f"[init] attributes: {self._attr_extra_state_attributes}")
         # _LOGGER.debug(f"[init] restore: {self._restore}")
         # _LOGGER.debug(f"[init] force_update: {self._force_update}")
+
+    def disable_recorder(self):
+        if RECORDER_INSTANCE in self._hass.data:
+            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
+            _LOGGER.info(f"({self._attr_name}) [disable_recorder] Disabling Recorder")
+            if self.entity_id:
+                ha_history_recorder.entity_filter._exclude_e.add(self.entity_id)
+
+            _LOGGER.debug(
+                f"({self._attr_name}) [disable_recorder] _exclude_e: {ha_history_recorder.entity_filter._exclude_e}"
+            )
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""
@@ -142,16 +162,27 @@ class Variable(RestoreSensor):
                 # Unsure how to deal with state vs native_value on restore.
                 # Setting Restored state to override native_value for now.
                 # self._state = state.state
-                if (sensor is None or (
-                    sensor and state.state is not None
+                if sensor is None or (
+                    sensor
+                    and state.state is not None
                     and state.state.lower() != "none"
                     and sensor.native_value != state.state
-                )):
+                ):
                     _LOGGER.info(
                         f"({self._attr_name}) Restored values are different. "
                         f"native_value: {sensor.native_value} | state: {state.state}"
                     )
                     self._attr_native_value = state.state
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        if RECORDER_INSTANCE in self._hass.data:
+            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
+            if self.entity_id:
+                _LOGGER.debug(
+                    f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
+                )
+                ha_history_recorder.entity_filter._exclude_e.discard(self.entity_id)
 
     @property
     def should_poll(self):

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -18,7 +18,6 @@ from .const import (
     CONF_RESTORE,
     CONF_VALUE,
     CONF_VARIABLE_ID,
-    CONF_YAML_VARIABLE,
     DEFAULT_FORCE_UPDATE,
     DEFAULT_ICON,
     DEFAULT_REPLACE_ATTRIBUTES,
@@ -111,10 +110,18 @@ class Variable(RestoreSensor):
             self._attr_extra_state_attributes = config.get(CONF_ATTRIBUTES)
         self._restore = config.get(CONF_RESTORE)
         self._force_update = config.get(CONF_FORCE_UPDATE)
-        self._yaml_variable = config.get(CONF_YAML_VARIABLE)
         self.entity_id = generate_entity_id(
             ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
         )
+        # _LOGGER.debug(f"[init] name: {self._attr_name}")
+        # _LOGGER.debug(f"[init] variable_id: {self._variable_id}")
+        # _LOGGER.debug(f"[init] entity_id: {self.entity_id}")
+        # _LOGGER.debug(f"[init] unique_id: {self._attr_unique_id}")
+        # _LOGGER.debug(f"[init] icon: {self._attr_icon}")
+        # _LOGGER.debug(f"[init] value: {self._attr_is_on}")
+        # _LOGGER.debug(f"[init] attributes: {self._attr_extra_state_attributes}")
+        # _LOGGER.debug(f"[init] restore: {self._restore}")
+        # _LOGGER.debug(f"[init] force_update: {self._force_update}")
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""
@@ -135,12 +142,11 @@ class Variable(RestoreSensor):
                 # Unsure how to deal with state vs native_value on restore.
                 # Setting Restored state to override native_value for now.
                 # self._state = state.state
-                if sensor is None or (
-                    sensor
-                    and state.state is not None
+                if (sensor is None or (
+                    sensor and state.state is not None
                     and state.state.lower() != "none"
                     and sensor.native_value != state.state
-                ):
+                )):
                     _LOGGER.info(
                         f"({self._attr_name}) Restored values are different. "
                         f"native_value: {sensor.native_value} | state: {state.state}"
@@ -168,11 +174,7 @@ class Variable(RestoreSensor):
         updated_attributes = None
         updated_value = None
 
-        if (
-            not replace_attributes
-            and hasattr(self, "_attr_extra_state_attributes")
-            and self._attr_extra_state_attributes is not None
-        ):
+        if not replace_attributes and self._attr_extra_state_attributes is not None:
             updated_attributes = dict(self._attr_extra_state_attributes)
 
         if attributes is not None:

--- a/custom_components/variable/strings.json
+++ b/custom_components/variable/strings.json
@@ -16,7 +16,8 @@
           "value": "Initial Value",
           "attributes": "Initial Attributes",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Sensor Variable"
       },
@@ -29,7 +30,8 @@
           "value": "Initial Value",
           "attributes": "Initial Attributes",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Binary Sensor Variable"
       }
@@ -44,7 +46,8 @@
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Update existing Variable Sensor"
       },
@@ -54,7 +57,8 @@
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Update existing Variable Binary Sensor"
       }

--- a/custom_components/variable/strings.json
+++ b/custom_components/variable/strings.json
@@ -58,10 +58,19 @@
         },
         "description": "Update existing Variable Binary Sensor"
       }
-    },
-    "abort": {
-      "yaml_variable": "Cannot change options here for Variables created by YAML.\n\nTo use the User Interface to manage this Variable, you will need to:\n1. Remove it from YAML\n2. Delete the imported Variable entity from Home Assistant\n3. Restart Home Assistant\n4. Manually recreate it in Home Assistant, Integrations, +Add Integration.",
-      "yaml_update_error": "Unable to update YAML Sensor Variable"
+    }
+  },
+  "issues": {
+    "restart_required_variable": {
+      "title": "Delete the Variable YAML configuration and restart",
+      "fix_flow": {
+        "step": {
+          "confirm_restart": {
+            "title": "Delete the Variable YAML configuration and restart",
+            "description": "Your existing YAML configuration has been imported into the UI automatically.\n\nRemove the Variable YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue.\n\nClick Submit to Restart Home Assistant."
+          }
+        }
+      }
     }
   },
   "selector": {

--- a/custom_components/variable/translations/en.json
+++ b/custom_components/variable/translations/en.json
@@ -16,7 +16,8 @@
           "value": "Initial Value",
           "attributes": "Initial Attributes",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Sensor Variable\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       },
@@ -29,7 +30,8 @@
           "value": "Initial Value",
           "attributes": "Initial Attributes",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Binary Sensor Variable\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       }
@@ -44,7 +46,8 @@
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "**Updating Sensor:&nbsp;{entity_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       },
@@ -54,7 +57,8 @@
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "**Updating Binary Sensor:&nbsp;{entity_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       }

--- a/custom_components/variable/translations/en.json
+++ b/custom_components/variable/translations/en.json
@@ -58,10 +58,19 @@
         },
         "description": "**Updating Binary Sensor:&nbsp;{entity_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       }
-    },
-    "abort": {
-      "yaml_variable": "Cannot change options here for Variables created by YAML.\n\nTo use the User Interface to manage this Variable, you will need to:\n1. Remove it from YAML\n2. Delete the imported Variable entity from Home Assistant\n3. Restart Home Assistant\n4. Manually recreate it in Home Assistant, Integrations, +Add Integration.",
-      "yaml_update_error": "Unable to update YAML Sensor Variable"
+    }
+  },
+  "issues": {
+    "restart_required_variable": {
+      "title": "Delete the Variable YAML configuration and restart",
+      "fix_flow": {
+        "step": {
+          "confirm_restart": {
+            "title": "Delete the Variable YAML configuration and restart",
+            "description": "Your existing YAML configuration has been imported into the UI automatically.\n\nRemove the Variable YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue.\n\nClick Submit to Restart Home Assistant."
+          }
+        }
+      }
     }
   },
   "selector": {


### PR DESCRIPTION
For variables with large attributes, the event recorder will give a Warning if the attributes is >16kb. This will exclude the variable from the recorder.

Will need to factor this change into #45  as well.

Fixes #40 

Leaving as draft for now as this is based on v3.0.1. Will need to refactor once v3.1+ is released.