### PR TITLE
Option to exclude from recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Name | Required | Default | Description |
 `Initial Attributes` | `No` | | Initial attributes of the variable. If `Restore on Restart` is `False`, the variable will reset to this value on every restart
 `Restore on Restart` | `No` | `True` | If `True` will restore previous value on restart. If `False`, will reset to `Initial Value` and `Initial Attributes` on restart
 `Force Update` | `No` | `False` | Variable's `last_updated` time will change with any service calls to update the variable even if the value does not change
+`Exclude from Recorder` | `No` | `False` | For Variables with large attributes (>16 kB), enable this to prevent Recorder Errors.
 
 </details>
 
@@ -78,6 +79,7 @@ Name | Required | Default | Description |
 `Initial Attributes` | `No` | | Initial attributes of the variable. If `Restore on Restart` is `False`, the variable will reset to this value on every restart
 `Restore on Restart` | `No` | `True` | If `True` will restore previous value on restart. If `False`, will reset to `Initial Value` and `Initial Attributes` on restart
 `Force Update` | `No` | `False` | Variable's `last_updated` time will change with any service calls to update the variable even if the value does not change
+`Exclude from Recorder` | `No` | `False` | For Variables with large attributes (>16 kB), enable this to prevent Recorder Errors.
 
 </details>
 
@@ -98,6 +100,7 @@ Initial Value | `value` | `No` | | Initial value/state of the variable. If `Rest
 Initial Attributes | `attributes` | `No` | | Initial attributes of the variable. If `Restore on Restart` is `False`, the variable will reset to this value on every restart
 Restore on Restart | `restore` | `No` | `True` | If `True` will restore previous value on restart. If `False`, will reset to `Initial Value` and `Initial Attributes` on restart
 Force Update | `force_update` | `No` | `False` | Variable's `last_updated` time will change with any service calls to update the variable even if the value does not change
+Exclude from Recorder | `exclude_from_recorder` | `No` | `False` | For Variables with large attributes (>16 kB), set to `True` to prevent Recorder Errors.  
 
 #### Example:
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,55 @@ variable:
 
 </details>
 
+<details>
+<summary><h2>Alternate YAML Configuration</h2></summary>
+
+**Variables created via YAML will all start with `sensor.` and cannot be edited in the UI.**
+
+_You can have a combination of Variables created via the UI and via YAML._
+
+Add the component `variable` to your configuration and declare the variables you want.
+
+Name | yaml | Required | Default | Description |
+-- | -- | -- | -- | --
+Variable ID | `<key>:` | `Yes` | | The desired id of the new sensor (ex. `test_variable` would create an entity_id of `sensor.test_variable`)
+Name | `name` | `No` | | Friendly name of the variable sensor  
+Initial Value | `value` | `No` | | Initial value/state of the variable. If `Restore on Restart` is `False`, the variable will reset to this value on every restart
+Initial Attributes | `attributes` | `No` | | Initial attributes of the variable. If `Restore on Restart` is `False`, the variable will reset to this value on every restart
+Restore on Restart | `restore` | `No` | `True` | If `True` will restore previous value on restart. If `False`, will reset to `Initial Value` and `Initial Attributes` on restart
+Force Update | `force_update` | `No` | `False` | Variable's `last_updated` time will change with any service calls to update the variable even if the value does not change
+
+#### Example:
+
+```yaml
+variable:
+  countdown_timer:
+    value: 30
+    attributes:
+      friendly_name: 'Countdown'
+      icon: mdi:alarm
+  countdown_trigger:
+    name: Countdown
+    value: False
+  light_scene:
+    value: 'normal'
+    attributes:
+      previous: ''
+    restore: true
+  current_power_usage:
+    force_update: true
+
+  daily_download:
+    value: 0
+    restore: true
+    attributes:
+      state_class: measurement
+      unit_of_measurement: GB
+      icon: mdi:download
+```
+
+</details>
+
 ## Services
 
 There are instructions and selectors when the service is called from the Developer Tools or within a Script or Automation.

--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -1,6 +1,7 @@
 import logging
 
 from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorEntity
+from homeassistant.components.recorder import DATA_INSTANCE as RECORDER_INSTANCE
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ICON, CONF_NAME, STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
@@ -15,11 +16,13 @@ from .const import (
     ATTR_REPLACE_ATTRIBUTES,
     ATTR_VALUE,
     CONF_ATTRIBUTES,
+    CONF_EXCLUDE_FROM_RECORDER,
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
     CONF_VALUE,
     CONF_VARIABLE_ID,
     CONF_YAML_VARIABLE,
+    DEFAULT_EXCLUDE_FROM_RECORDER,
     DEFAULT_FORCE_UPDATE,
     DEFAULT_ICON,
     DEFAULT_REPLACE_ATTRIBUTES,
@@ -41,6 +44,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_ATTRIBUTES): dict,
         vol.Optional(CONF_RESTORE, default=DEFAULT_RESTORE): cv.boolean,
         vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
+        vol.Optional(
+            CONF_EXCLUDE_FROM_RECORDER, default=DEFAULT_EXCLUDE_FROM_RECORDER
+        ): cv.boolean,
     }
 )
 
@@ -118,9 +124,23 @@ class Variable(BinarySensorEntity, RestoreEntity):
         self._restore = config.get(CONF_RESTORE)
         self._force_update = config.get(CONF_FORCE_UPDATE)
         self._yaml_variable = config.get(CONF_YAML_VARIABLE)
+        self._exclude_from_recorder = config.get(CONF_EXCLUDE_FROM_RECORDER)
         self.entity_id = generate_entity_id(
             ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
         )
+        if self._exclude_from_recorder:
+            self.disable_recorder()
+
+    def disable_recorder(self):
+        if RECORDER_INSTANCE in self._hass.data:
+            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
+            _LOGGER.info(f"({self._attr_name}) [disable_recorder] Disabling Recorder")
+            if self.entity_id:
+                ha_history_recorder.entity_filter._exclude_e.add(self.entity_id)
+
+            _LOGGER.debug(
+                f"({self._attr_name}) [disable_recorder] _exclude_e: {ha_history_recorder.entity_filter._exclude_e}"
+            )
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""
@@ -137,6 +157,16 @@ class Variable(BinarySensorEntity, RestoreEntity):
                     self._attr_is_on = True
                 else:
                     self._attr_is_on = state.state
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        if RECORDER_INSTANCE in self._hass.data:
+            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
+            if self.entity_id:
+                _LOGGER.debug(
+                    f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
+                )
+                ha_history_recorder.entity_filter._exclude_e.discard(self.entity_id)
 
     @property
     def should_poll(self):

--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -1,9 +1,19 @@
+import copy
 import logging
 
 from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorEntity
 from homeassistant.components.recorder import DATA_INSTANCE as RECORDER_INSTANCE
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ICON, CONF_NAME, STATE_OFF, STATE_ON, Platform
+from homeassistant.const import (
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
+    CONF_DEVICE_CLASS,
+    CONF_ICON,
+    CONF_NAME,
+    STATE_OFF,
+    STATE_ON,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import generate_entity_id
@@ -51,6 +61,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 SERVICE_UPDATE_VARIABLE = "update_" + PLATFORM
+
+VARIABLE_ATTR_SETTINGS = {ATTR_FRIENDLY_NAME: "_attr_name", ATTR_ICON: "_attr_icon"}
 
 
 async def async_setup_entry(
@@ -120,10 +132,14 @@ class Variable(BinarySensorEntity, RestoreEntity):
             self._attr_name = config.get(CONF_VARIABLE_ID)
         self._attr_icon = config.get(CONF_ICON)
         self._attr_is_on = bool_val
-        self._attr_extra_state_attributes = config.get(CONF_ATTRIBUTES)
+        self._attr_device_class = config.get(CONF_DEVICE_CLASS)
         self._restore = config.get(CONF_RESTORE)
         self._force_update = config.get(CONF_FORCE_UPDATE)
         self._yaml_variable = config.get(CONF_YAML_VARIABLE)
+        if config.get(CONF_ATTRIBUTES) is not None and config.get(CONF_ATTRIBUTES):
+            self._attr_extra_state_attributes = self._update_attr_settings(
+                config.get(CONF_ATTRIBUTES)
+            )
         self._exclude_from_recorder = config.get(CONF_EXCLUDE_FROM_RECORDER)
         self.entity_id = generate_entity_id(
             ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
@@ -150,7 +166,9 @@ class Variable(BinarySensorEntity, RestoreEntity):
             state = await self.async_get_last_state()
             if state:
                 _LOGGER.debug(f"({self._attr_name}) Restored state: {state.as_dict()}")
-                self._attr_extra_state_attributes = state.attributes
+                self._attr_extra_state_attributes = self._update_attr_settings(
+                    state.attributes.copy()
+                )
                 if state.state == STATE_OFF:
                     self._attr_is_on = False
                 elif state.state == STATE_ON:
@@ -178,6 +196,19 @@ class Variable(BinarySensorEntity, RestoreEntity):
         """Force update status of the entity."""
         return self._force_update
 
+    def _update_attr_settings(self, new_attributes=None):
+        if new_attributes is not None:
+            attributes = copy.deepcopy(new_attributes)
+            for attrib, setting in VARIABLE_ATTR_SETTINGS.items():
+                if attrib in attributes.keys():
+                    _LOGGER.debug(
+                        f"({self._attr_name}) [update_attr_settings] attrib: {attrib} / setting: {setting} / value: {attributes.get(attrib)}"
+                    )
+                    setattr(self, setting, attributes.pop(attrib, None))
+            return copy.deepcopy(attributes)
+        else:
+            return None
+
     async def async_update_variable(
         self,
         value=None,
@@ -190,29 +221,38 @@ class Variable(BinarySensorEntity, RestoreEntity):
         # _LOGGER.debug(f"value: {value}")
         # _LOGGER.debug(f"attributes: {attributes}")
         updated_attributes = None
-        updated_value = None
+
+        _LOGGER.debug(
+            f"({self._attr_name}) [async_update_variable] Replace Attributes: {replace_attributes}"
+        )
 
         if (
             not replace_attributes
             and hasattr(self, "_attr_extra_state_attributes")
             and self._attr_extra_state_attributes is not None
         ):
-            updated_attributes = dict(self._attr_extra_state_attributes)
+            updated_attributes = copy.deepcopy(self._attr_extra_state_attributes)
 
         if attributes is not None:
+            _LOGGER.debug(
+                f"({self._attr_name}) [async_update_variable] New Attributes: {attributes}"
+            )
+            extra_attributes = self._update_attr_settings(attributes)
             if updated_attributes is not None:
-                updated_attributes.update(attributes)
+                updated_attributes.update(extra_attributes)
             else:
-                updated_attributes = attributes
+                updated_attributes = extra_attributes
 
-        if value is not None:
-            updated_value = value
+        self._attr_extra_state_attributes = copy.deepcopy(updated_attributes)
 
-        self._attr_extra_state_attributes = updated_attributes
+        if updated_attributes is not None:
+            _LOGGER.debug(
+                f"({self._attr_name}) [async_update_variable] Final Attributes: {updated_attributes}"
+            )
 
-        if updated_value is None:
+        if value is None:
             self._attr_is_on = False
         else:
-            self._attr_is_on = updated_value
+            self._attr_is_on = value
 
         await self.async_update_ha_state()

--- a/custom_components/variable/config_flow.py
+++ b/custom_components/variable/config_flow.py
@@ -14,11 +14,13 @@ import voluptuous as vol
 from .const import (
     CONF_ATTRIBUTES,
     CONF_ENTITY_PLATFORM,
+    CONF_EXCLUDE_FROM_RECORDER,
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
     CONF_VALUE,
     CONF_VARIABLE_ID,
     CONF_YAML_VARIABLE,
+    DEFAULT_EXCLUDE_FROM_RECORDER,
     DEFAULT_FORCE_UPDATE,
     DEFAULT_ICON,
     DEFAULT_RESTORE,
@@ -51,6 +53,9 @@ ADD_SENSOR_SCHEMA = vol.Schema(
         vol.Optional(
             CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE
         ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+        vol.Optional(
+            CONF_EXCLUDE_FROM_RECORDER, default=DEFAULT_EXCLUDE_FROM_RECORDER
+        ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
     }
 )
 
@@ -78,6 +83,9 @@ ADD_BINARY_SENSOR_SCHEMA = vol.Schema(
         ),
         vol.Optional(
             CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE
+        ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+        vol.Optional(
+            CONF_EXCLUDE_FROM_RECORDER, default=DEFAULT_EXCLUDE_FROM_RECORDER
         ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
     }
 )
@@ -251,6 +259,12 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_FORCE_UPDATE, DEFAULT_FORCE_UPDATE
                     ),
                 ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+                vol.Optional(
+                    CONF_EXCLUDE_FROM_RECORDER,
+                    default=self.config_entry.data.get(
+                        CONF_EXCLUDE_FROM_RECORDER, DEFAULT_EXCLUDE_FROM_RECORDER
+                    ),
+                ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
             }
         )
 
@@ -307,6 +321,12 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_FORCE_UPDATE,
                     default=self.config_entry.data.get(
                         CONF_FORCE_UPDATE, DEFAULT_FORCE_UPDATE
+                    ),
+                ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+                vol.Optional(
+                    CONF_EXCLUDE_FROM_RECORDER,
+                    default=self.config_entry.data.get(
+                        CONF_EXCLUDE_FROM_RECORDER, DEFAULT_EXCLUDE_FROM_RECORDER
                     ),
                 ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
             }

--- a/custom_components/variable/config_flow.py
+++ b/custom_components/variable/config_flow.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+from enum import Enum
 import logging
 from typing import Any
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_ICON, CONF_NAME, Platform
+from homeassistant.components import binary_sensor, sensor
+from homeassistant.const import (
+    CONF_DEVICE_CLASS,
+    CONF_ICON,
+    CONF_NAME,
+    CONF_UNIT_OF_MEASUREMENT,
+    Platform,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
@@ -18,6 +26,7 @@ from .const import (
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
     CONF_VALUE,
+    CONF_VALUE_TYPE,
     CONF_VARIABLE_ID,
     CONF_YAML_VARIABLE,
     DEFAULT_EXCLUDE_FROM_RECORDER,
@@ -27,6 +36,10 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
+from .helpers import value_to_type
+
+# sensor: SensorDeviceClass, DEVICE_CLASS_STATE_CLASSES, DEVICE_CLASS_UNITS
+# binary_sensor: BinarySensorDeviceClass
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,6 +49,25 @@ COMPONENT_CONFIG_URL = "https://github.com/Wibias/hass-variables"
 # translations/<lang>.json file and strings.json. See here for further information:
 # https://developers.home-assistant.io/docs/config_entries_config_flow_handler/#translations
 
+SENSOR_DEVICE_CLASS_SELECT_LIST = []
+SENSOR_DEVICE_CLASS_SELECT_LIST.append(
+    selector.SelectOptionDict(label="None", value="None")
+)
+for el in sensor.SensorDeviceClass:
+    if el != sensor.SensorDeviceClass.ENUM:
+        SENSOR_DEVICE_CLASS_SELECT_LIST.append(
+            selector.SelectOptionDict(label=str(el.name), value=str(el.value))
+        )
+
+BINARY_SENSOR_DEVICE_CLASS_SELECT_LIST = []
+BINARY_SENSOR_DEVICE_CLASS_SELECT_LIST.append(
+    selector.SelectOptionDict(label="None", value="None")
+)
+for el in binary_sensor.BinarySensorDeviceClass:
+    BINARY_SENSOR_DEVICE_CLASS_SELECT_LIST.append(
+        selector.SelectOptionDict(label=str(el.name), value=str(el.value))
+    )
+
 ADD_SENSOR_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_VARIABLE_ID): cv.string,
@@ -43,9 +75,13 @@ ADD_SENSOR_SCHEMA = vol.Schema(
         vol.Optional(CONF_ICON, default=DEFAULT_ICON): selector.IconSelector(
             selector.IconSelectorConfig()
         ),
-        vol.Optional(CONF_VALUE): cv.string,
-        vol.Optional(CONF_ATTRIBUTES): selector.ObjectSelector(
-            selector.ObjectSelectorConfig()
+        vol.Optional(CONF_DEVICE_CLASS): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=SENSOR_DEVICE_CLASS_SELECT_LIST,
+                multiple=False,
+                custom_value=False,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )
         ),
         vol.Optional(CONF_RESTORE, default=DEFAULT_RESTORE): selector.BooleanSelector(
             selector.BooleanSelectorConfig()
@@ -77,6 +113,14 @@ ADD_BINARY_SENSOR_SCHEMA = vol.Schema(
         ),
         vol.Optional(CONF_ATTRIBUTES): selector.ObjectSelector(
             selector.ObjectSelectorConfig()
+        ),
+        vol.Optional(CONF_DEVICE_CLASS): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=BINARY_SENSOR_DEVICE_CLASS_SELECT_LIST,
+                multiple=False,
+                custom_value=False,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )
         ),
         vol.Optional(CONF_RESTORE, default=DEFAULT_RESTORE): selector.BooleanSelector(
             selector.BooleanSelectorConfig()
@@ -118,16 +162,11 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input=None, errors=None, yaml_variable=False
     ):
         if user_input is not None:
-
+            user_input.update({CONF_ENTITY_PLATFORM: Platform.SENSOR})
             try:
-                user_input.update({CONF_ENTITY_PLATFORM: Platform.SENSOR})
-                user_input.update({CONF_YAML_VARIABLE: yaml_variable})
-                info = await validate_sensor_input(self.hass, user_input)
-                _LOGGER.debug(f"[New Sensor Variable] info: {info}")
-                _LOGGER.debug(f"[New Sensor Variable] user_input: {user_input}")
-                return self.async_create_entry(
-                    title=info.get("title", ""), data=user_input
-                )
+                _LOGGER.debug(f"[New Sensor Page 1] page_1_input: {user_input}")
+                self.add_sensor_input = user_input
+                return await self.async_step_sensor_page_2()
             except Exception as err:
                 _LOGGER.exception(
                     f"[config_flow async_step_add_sensor] Unexpected exception: {err}"
@@ -144,6 +183,182 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
+    async def async_step_sensor_page_2(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            _LOGGER.debug(f"[New Sensor Page 2] page_1_input: {self.add_sensor_input}")
+            _LOGGER.debug(f"[New Sensor Page 2] page_2_input: {user_input}")
+
+            try:
+                newval = value_to_type(
+                    user_input.get(CONF_VALUE),
+                    self.add_sensor_input.get(CONF_VALUE_TYPE),
+                )
+            except ValueError:
+                errors["base"] = "invalid_value_type"
+            else:
+                user_input[CONF_VALUE] = newval
+
+            _LOGGER.debug(
+                f"[New Sensor Page 2] value_type: {self.add_sensor_input.get(CONF_VALUE_TYPE)}"
+            )
+            _LOGGER.debug(
+                f"[New Sensor Page 2] type of value: {type(user_input.get(CONF_VALUE))}"
+            )
+
+            if not errors:
+                if self.add_sensor_input is not None and self.add_sensor_input:
+                    user_input.update(self.add_sensor_input)
+                if user_input is not None:
+                    for k, v in list(user_input.items()):
+                        if v is None or (isinstance(v, str) and v.lower() == "none"):
+                            user_input.pop(k, None)
+                _LOGGER.debug(f"[New Sensor Page 2] Final user_input: {user_input}")
+                info = await validate_sensor_input(self.hass, user_input)
+                return self.async_create_entry(
+                    title=info.get("title", ""), data=user_input
+                )
+
+        _LOGGER.debug(f"[New Sensor Page 2] Initial user_input: {user_input}")
+        _LOGGER.debug(
+            f"[New Sensor Page 2] device_class: {self.add_sensor_input.get(CONF_DEVICE_CLASS)}"
+        )
+
+        SENSOR_STATE_CLASS_SELECT_LIST = []
+        SENSOR_STATE_CLASS_SELECT_LIST.append(
+            selector.SelectOptionDict(label="None", value="None")
+        )
+        SENSOR_UNITS_SELECT_LIST = []
+        SENSOR_UNITS_SELECT_LIST.append(
+            selector.SelectOptionDict(label="None", value="None")
+        )
+
+        SENSOR_PAGE_2_SCHEMA = vol.Schema({})
+        if (
+            self.add_sensor_input.get(CONF_DEVICE_CLASS) is not None
+            and self.add_sensor_input.get(CONF_DEVICE_CLASS).lower() != "none"
+        ):
+            for el in sensor.DEVICE_CLASS_STATE_CLASSES.get(
+                self.add_sensor_input.get(CONF_DEVICE_CLASS), Enum
+            ):
+                SENSOR_STATE_CLASS_SELECT_LIST.append(
+                    selector.SelectOptionDict(label=str(el.name), value=str(el.value))
+                )
+            for el in sensor.DEVICE_CLASS_UNITS.get(
+                self.add_sensor_input.get(CONF_DEVICE_CLASS), []
+            ):
+                SENSOR_UNITS_SELECT_LIST.append(
+                    selector.SelectOptionDict(label=str(el), value=str(el))
+                )
+
+            if self.add_sensor_input.get(CONF_DEVICE_CLASS) in [
+                sensor.SensorDeviceClass.DATE
+            ]:
+                SENSOR_PAGE_2_SCHEMA = SENSOR_PAGE_2_SCHEMA.extend(
+                    {
+                        vol.Optional(CONF_VALUE): selector.DateSelector(
+                            selector.DateSelectorConfig()
+                        )
+                    }
+                )
+                value_type = "date"
+            elif self.add_sensor_input.get(CONF_DEVICE_CLASS) in [
+                sensor.SensorDeviceClass.TIMESTAMP
+            ]:
+                SENSOR_PAGE_2_SCHEMA = SENSOR_PAGE_2_SCHEMA.extend(
+                    {
+                        vol.Optional(CONF_VALUE): selector.DateTimeSelector(
+                            selector.DateTimeSelectorConfig()
+                        )
+                    }
+                )
+                value_type = "datetime"
+            else:
+                SENSOR_PAGE_2_SCHEMA = SENSOR_PAGE_2_SCHEMA.extend(
+                    {
+                        vol.Optional(CONF_VALUE): selector.TextSelector(
+                            selector.TextSelectorConfig()
+                        )
+                    }
+                )
+                value_type = "number"
+        else:
+            for el in sensor.SensorStateClass:
+                SENSOR_STATE_CLASS_SELECT_LIST.append(
+                    selector.SelectOptionDict(label=str(el.name), value=str(el.value))
+                )
+
+            SENSOR_PAGE_2_SCHEMA = SENSOR_PAGE_2_SCHEMA.extend(
+                {
+                    vol.Optional(CONF_VALUE): selector.TextSelector(
+                        selector.TextSelectorConfig()
+                    )
+                }
+            )
+            value_type = "string"
+
+        # _LOGGER.debug(
+        #    f"[New Sensor Page 2] SENSOR_STATE_CLASS_SELECT_LIST: {SENSOR_STATE_CLASS_SELECT_LIST}"
+        # )
+        # _LOGGER.debug(
+        #    f"[New Sensor Page 2] SENSOR_UNITS_SELECT_LIST: {SENSOR_UNITS_SELECT_LIST}"
+        # )
+
+        SENSOR_PAGE_2_SCHEMA = SENSOR_PAGE_2_SCHEMA.extend(
+            {
+                vol.Optional(CONF_ATTRIBUTES): selector.ObjectSelector(
+                    selector.ObjectSelectorConfig()
+                )
+            }
+        )
+        if len(SENSOR_STATE_CLASS_SELECT_LIST) > 1:
+            SENSOR_PAGE_2_SCHEMA = SENSOR_PAGE_2_SCHEMA.extend(
+                {
+                    vol.Optional(sensor.CONF_STATE_CLASS): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=SENSOR_STATE_CLASS_SELECT_LIST,
+                            multiple=False,
+                            custom_value=False,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                }
+            )
+
+        if len(SENSOR_UNITS_SELECT_LIST) > 1:
+            SENSOR_PAGE_2_SCHEMA = SENSOR_PAGE_2_SCHEMA.extend(
+                {
+                    vol.Optional(CONF_UNIT_OF_MEASUREMENT): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=SENSOR_UNITS_SELECT_LIST,
+                            multiple=False,
+                            custom_value=False,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                }
+            )
+
+        _LOGGER.debug(f"[New Sensor Page 2] value_type: {value_type}")
+        self.add_sensor_input.update({CONF_VALUE_TYPE: value_type})
+        if self.add_sensor_input.get(CONF_NAME) is None or self.add_sensor_input.get(
+            CONF_NAME
+        ) == self.add_sensor_input.get(CONF_VARIABLE_ID):
+            disp_name = self.add_sensor_input.get(CONF_VARIABLE_ID)
+        else:
+            disp_name = f"{self.add_sensor_input.get(CONF_NAME)} ({self.add_sensor_input.get(CONF_VARIABLE_ID)})"
+        # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
+        return self.async_show_form(
+            step_id="sensor_page_2",
+            data_schema=SENSOR_PAGE_2_SCHEMA,
+            errors=errors,
+            description_placeholders={
+                "device_class": self.add_sensor_input.get(CONF_DEVICE_CLASS, "None"),
+                "disp_name": disp_name,
+                "value_type": value_type,
+            },
+        )
+
     async def async_step_add_binary_sensor(
         self, user_input=None, errors=None, yaml_variable=False
     ):
@@ -153,8 +368,7 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input.update({CONF_ENTITY_PLATFORM: Platform.BINARY_SENSOR})
                 user_input.update({CONF_YAML_VARIABLE: yaml_variable})
                 info = await validate_sensor_input(self.hass, user_input)
-                _LOGGER.debug(f"[New Binary Sensor Variable] info: {info}")
-                _LOGGER.debug(f"[Sensor Options] updated user_input: {user_input}")
+                _LOGGER.debug(f"[New Binary Sensor] updated user_input: {user_input}")
                 return self.async_create_entry(
                     title=info.get("title", ""), data=user_input
                 )
@@ -228,27 +442,23 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
     ) -> FlowResult:
 
         if user_input is not None:
-            _LOGGER.debug(f"[Sensor Options] user_input: {user_input}")
-
-            for m in dict(self.config_entry.data).keys():
-                user_input.setdefault(m, self.config_entry.data[m])
-            _LOGGER.debug(f"[Sensor Options] updated user_input: {user_input}")
-            self.config_entry.options = {}
-
-            self.hass.config_entries.async_update_entry(
-                self.config_entry, data=user_input, options=self.config_entry.options
-            )
-            await self.hass.config_entries.async_reload(self.config_entry.entry_id)
-            return self.async_create_entry(title="", data=user_input)
+            _LOGGER.debug(f"[Sensor Options Page 1] page_1_input: {user_input}")
+            self.sensor_options_page_1 = user_input
+            return await self.async_step_sensor_options_page_2()
 
         SENSOR_OPTIONS_SCHEMA = vol.Schema(
             {
                 vol.Optional(
-                    CONF_VALUE, default=self.config_entry.data.get(CONF_VALUE)
-                ): cv.string,
-                vol.Optional(
-                    CONF_ATTRIBUTES, default=self.config_entry.data.get(CONF_ATTRIBUTES)
-                ): selector.ObjectSelector(selector.ObjectSelectorConfig()),
+                    CONF_DEVICE_CLASS,
+                    default=self.config_entry.data.get(CONF_DEVICE_CLASS, "None"),
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=SENSOR_DEVICE_CLASS_SELECT_LIST,
+                        multiple=False,
+                        custom_value=False,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
                 vol.Optional(
                     CONF_RESTORE,
                     default=self.config_entry.data.get(CONF_RESTORE, DEFAULT_RESTORE),
@@ -267,14 +477,282 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
                 ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
             }
         )
+        if self.config_entry.data.get(CONF_NAME) is None or self.config_entry.data.get(
+            CONF_NAME
+        ) == self.config_entry.data.get(CONF_VARIABLE_ID):
+            disp_name = self.config_entry.data.get(CONF_VARIABLE_ID)
+        else:
+            disp_name = f"{self.config_entry.data.get(CONF_NAME)} ({self.config_entry.data.get(CONF_VARIABLE_ID)})"
 
         return self.async_show_form(
             step_id="sensor_options",
             data_schema=SENSOR_OPTIONS_SCHEMA,
             description_placeholders={
                 "component_config_url": COMPONENT_CONFIG_URL,
-                "entity_name": self.config_entry.data.get(
-                    CONF_NAME, self.config_entry.data.get(CONF_VARIABLE_ID)
+                "disp_name": disp_name,
+            },
+        )
+
+    async def async_step_sensor_options_page_2(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            _LOGGER.debug(f"[Sensor Options Page 2] user_input: {user_input}")
+            try:
+                newval = value_to_type(
+                    user_input.get(CONF_VALUE),
+                    self.sensor_options_page_1.get(CONF_VALUE_TYPE),
+                )
+            except ValueError:
+                errors["base"] = "invalid_value_type"
+            else:
+                user_input[CONF_VALUE] = newval
+
+            _LOGGER.debug(
+                f"[Sensor Options Page 2] value_type: {self.sensor_options_page_1.get(CONF_VALUE_TYPE)}"
+            )
+            _LOGGER.debug(
+                f"[Sensor Options Page 2] type of value: {type(user_input.get(CONF_VALUE))}"
+            )
+
+            if not errors:
+                if (
+                    self.sensor_options_page_1 is not None
+                    and self.sensor_options_page_1
+                ):
+                    user_input.update(self.sensor_options_page_1)
+                for m in dict(self.config_entry.data).keys():
+                    user_input.setdefault(m, self.config_entry.data[m])
+                if user_input is not None:
+                    for k, v in list(user_input.items()):
+                        if v is None or (isinstance(v, str) and v.lower() == "none"):
+                            user_input.pop(k, None)
+                _LOGGER.debug(f"[Sensor Options Page 2] Final user_input: {user_input}")
+                self.config_entry.options = {}
+
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    data=user_input,
+                    options=self.config_entry.options,
+                )
+                await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+                return self.async_create_entry(title="", data=user_input)
+
+        _LOGGER.debug(f"[Sensor Options Page 2] Initial user_input: {user_input}")
+        _LOGGER.debug(
+            f"[Sensor Options Page 2] device_class: {self.sensor_options_page_1.get(CONF_DEVICE_CLASS)}"
+        )
+
+        SENSOR_STATE_CLASS_SELECT_LIST = []
+        SENSOR_STATE_CLASS_SELECT_LIST.append(
+            selector.SelectOptionDict(label="None", value="None")
+        )
+        SENSOR_UNITS_SELECT_LIST = []
+        SENSOR_UNITS_SELECT_LIST.append(
+            selector.SelectOptionDict(label="None", value="None")
+        )
+
+        if self.config_entry.data.get(CONF_VALUE) is None or (
+            isinstance(self.config_entry.data.get(CONF_VALUE), str)
+            and self.config_entry.data.get(CONF_VALUE).lower() == "none"
+        ):
+            val_default = False
+        elif self.config_entry.data.get(
+            CONF_DEVICE_CLASS
+        ) != self.sensor_options_page_1.get(CONF_DEVICE_CLASS):
+            val_default = False
+        else:
+            val_default = True
+            val_default_value = self.config_entry.data.get(CONF_VALUE)
+
+        SENSOR_OPTIONS_PAGE_2_SCHEMA = vol.Schema({})
+        if (
+            self.sensor_options_page_1.get(CONF_DEVICE_CLASS) is not None
+            and self.sensor_options_page_1.get(CONF_DEVICE_CLASS).lower() != "none"
+        ):
+            for el in sensor.DEVICE_CLASS_STATE_CLASSES.get(
+                self.sensor_options_page_1.get(CONF_DEVICE_CLASS), Enum
+            ):
+                SENSOR_STATE_CLASS_SELECT_LIST.append(
+                    selector.SelectOptionDict(label=str(el.name), value=str(el.value))
+                )
+            for el in sensor.DEVICE_CLASS_UNITS.get(
+                self.sensor_options_page_1.get(CONF_DEVICE_CLASS), []
+            ):
+                SENSOR_UNITS_SELECT_LIST.append(
+                    selector.SelectOptionDict(label=str(el), value=str(el))
+                )
+
+            if self.sensor_options_page_1.get(CONF_DEVICE_CLASS) in [
+                sensor.SensorDeviceClass.DATE
+            ]:
+                value_type = "date"
+                if val_default:
+                    SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                        {
+                            vol.Optional(
+                                CONF_VALUE,
+                                default=val_default_value,
+                            ): selector.DateSelector(selector.DateSelectorConfig())
+                        }
+                    )
+                else:
+                    SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                        {
+                            vol.Optional(
+                                CONF_VALUE,
+                            ): selector.DateSelector(selector.DateSelectorConfig())
+                        }
+                    )
+
+            elif self.sensor_options_page_1.get(CONF_DEVICE_CLASS) in [
+                sensor.SensorDeviceClass.TIMESTAMP
+            ]:
+                value_type = "datetime"
+                if val_default:
+                    SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                        {
+                            vol.Optional(
+                                CONF_VALUE,
+                                default=val_default_value,
+                            ): selector.DateTimeSelector(
+                                selector.DateTimeSelectorConfig()
+                            )
+                        }
+                    )
+                else:
+                    SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                        {
+                            vol.Optional(CONF_VALUE,): selector.DateTimeSelector(
+                                selector.DateTimeSelectorConfig()
+                            )
+                        }
+                    )
+            else:
+                value_type = "number"
+                if val_default:
+                    SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                        {
+                            vol.Optional(
+                                CONF_VALUE,
+                                default=val_default_value,
+                            ): selector.TextSelector(selector.TextSelectorConfig())
+                        }
+                    )
+                else:
+                    SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                        {
+                            vol.Optional(
+                                CONF_VALUE,
+                            ): selector.TextSelector(selector.TextSelectorConfig())
+                        }
+                    )
+        else:
+            for el in sensor.SensorStateClass:
+                SENSOR_STATE_CLASS_SELECT_LIST.append(
+                    selector.SelectOptionDict(label=str(el.name), value=str(el.value))
+                )
+            value_type = "string"
+            if val_default:
+                SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                    {
+                        vol.Optional(
+                            CONF_VALUE,
+                            default=val_default_value,
+                        ): selector.TextSelector(selector.TextSelectorConfig())
+                    }
+                )
+            else:
+                SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                    {
+                        vol.Optional(
+                            CONF_VALUE,
+                        ): selector.TextSelector(selector.TextSelectorConfig())
+                    }
+                )
+
+        # _LOGGER.debug(
+        #    f"[Sensor Options Page 2] SENSOR_STATE_CLASS_SELECT_LIST: {SENSOR_STATE_CLASS_SELECT_LIST}"
+        # )
+        # _LOGGER.debug(
+        #    f"[Sensor Options Page 2] SENSOR_UNITS_SELECT_LIST: {SENSOR_UNITS_SELECT_LIST}"
+        # )
+
+        SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+            {
+                vol.Optional(
+                    CONF_ATTRIBUTES, default=self.config_entry.data.get(CONF_ATTRIBUTES)
+                ): selector.ObjectSelector(selector.ObjectSelectorConfig())
+            }
+        )
+        if len(SENSOR_STATE_CLASS_SELECT_LIST) > 1:
+            SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                {
+                    vol.Optional(
+                        sensor.CONF_STATE_CLASS,
+                        default=self.config_entry.data.get(
+                            sensor.CONF_STATE_CLASS, "None"
+                        )
+                        if (
+                            self.config_entry.data.get(CONF_DEVICE_CLASS)
+                            == self.sensor_options_page_1.get(CONF_DEVICE_CLASS)
+                        )
+                        else "None",
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=SENSOR_STATE_CLASS_SELECT_LIST,
+                            multiple=False,
+                            custom_value=False,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                }
+            )
+        else:
+            self.sensor_options_page_1[sensor.CONF_STATE_CLASS] = None
+
+        if len(SENSOR_UNITS_SELECT_LIST) > 1:
+            SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                {
+                    vol.Optional(
+                        CONF_UNIT_OF_MEASUREMENT,
+                        default=self.config_entry.data.get(
+                            CONF_UNIT_OF_MEASUREMENT, "None"
+                        )
+                        if (
+                            self.config_entry.data.get(CONF_DEVICE_CLASS)
+                            == self.sensor_options_page_1.get(CONF_DEVICE_CLASS)
+                        )
+                        else "None",
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=SENSOR_UNITS_SELECT_LIST,
+                            multiple=False,
+                            custom_value=False,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                }
+            )
+        else:
+            self.sensor_options_page_1[CONF_UNIT_OF_MEASUREMENT] = None
+
+        if self.config_entry.data.get(CONF_NAME) is None or self.config_entry.data.get(
+            CONF_NAME
+        ) == self.config_entry.data.get(CONF_VARIABLE_ID):
+            disp_name = self.config_entry.data.get(CONF_VARIABLE_ID)
+        else:
+            disp_name = f"{self.config_entry.data.get(CONF_NAME)} ({self.config_entry.data.get(CONF_VARIABLE_ID)})"
+
+        _LOGGER.debug(f"[Sensor Options Page 2] value_type: {value_type}")
+        self.sensor_options_page_1.update({CONF_VALUE_TYPE: value_type})
+        return self.async_show_form(
+            step_id="sensor_options_page_2",
+            data_schema=SENSOR_OPTIONS_PAGE_2_SCHEMA,
+            description_placeholders={
+                "disp_name": disp_name,
+                "value_type": value_type,
+                "device_class": self.sensor_options_page_1.get(
+                    CONF_DEVICE_CLASS, "None"
                 ),
             },
         )
@@ -314,6 +792,17 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_ATTRIBUTES, default=self.config_entry.data.get(CONF_ATTRIBUTES)
                 ): selector.ObjectSelector(selector.ObjectSelectorConfig()),
                 vol.Optional(
+                    CONF_DEVICE_CLASS,
+                    default=self.config_entry.data.get(CONF_DEVICE_CLASS, "None"),
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=BINARY_SENSOR_DEVICE_CLASS_SELECT_LIST,
+                        multiple=False,
+                        custom_value=False,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
+                vol.Optional(
                     CONF_RESTORE,
                     default=self.config_entry.data.get(CONF_RESTORE, DEFAULT_RESTORE),
                 ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
@@ -332,13 +821,18 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
             }
         )
 
+        if self.config_entry.data.get(CONF_NAME) is None or self.config_entry.data.get(
+            CONF_NAME
+        ) == self.config_entry.data.get(CONF_VARIABLE_ID):
+            disp_name = self.config_entry.data.get(CONF_VARIABLE_ID)
+        else:
+            disp_name = f"{self.config_entry.data.get(CONF_NAME)} ({self.config_entry.data.get(CONF_VARIABLE_ID)})"
+
         return self.async_show_form(
             step_id="binary_sensor_options",
             data_schema=BINARY_SENSOR_OPTIONS_SCHEMA,
             description_placeholders={
                 "component_config_url": COMPONENT_CONFIG_URL,
-                "entity_name": self.config_entry.data.get(
-                    CONF_NAME, self.config_entry.data.get(CONF_VARIABLE_ID)
-                ),
+                "disp_name": disp_name,
             },
         )

--- a/custom_components/variable/const.py
+++ b/custom_components/variable/const.py
@@ -1,5 +1,6 @@
 from homeassistant.const import Platform
 
+PLAFORM_NAME = "Variables+History"
 DOMAIN = "variable"
 
 PLATFORMS: list[str] = [Platform.SENSOR, Platform.BINARY_SENSOR]
@@ -16,6 +17,7 @@ CONF_ENTITY_PLATFORM = "entity_platform"
 CONF_FORCE_UPDATE = "force_update"
 CONF_RESTORE = "restore"
 CONF_VALUE = "value"
+CONF_VALUE_TYPE = "value_type"
 CONF_VARIABLE_ID = "variable_id"
 CONF_YAML_VARIABLE = "yaml_variable"
 CONF_EXCLUDE_FROM_RECORDER = "exclude_from_recorder"

--- a/custom_components/variable/const.py
+++ b/custom_components/variable/const.py
@@ -9,6 +9,7 @@ DEFAULT_FORCE_UPDATE = False
 DEFAULT_ICON = "mdi:variable"
 DEFAULT_REPLACE_ATTRIBUTES = False
 DEFAULT_RESTORE = True
+DEFAULT_EXCLUDE_FROM_RECORDER = False
 
 CONF_ATTRIBUTES = "attributes"
 CONF_ENTITY_PLATFORM = "entity_platform"
@@ -17,6 +18,7 @@ CONF_RESTORE = "restore"
 CONF_VALUE = "value"
 CONF_VARIABLE_ID = "variable_id"
 CONF_YAML_VARIABLE = "yaml_variable"
+CONF_EXCLUDE_FROM_RECORDER = "exclude_from_recorder"
 
 ATTR_ATTRIBUTES = "attributes"
 ATTR_ENTITY = "entity"

--- a/custom_components/variable/helpers.py
+++ b/custom_components/variable/helpers.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import datetime
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def to_num(s):
+    try:
+        return int(s)
+    except ValueError:
+        try:
+            return float(s)
+        except ValueError:
+            return None
+
+
+def value_to_type(init_str, value_type):
+
+    if value_type == "date":
+        if init_str is None:
+            return None
+        else:
+            try:
+                value_date = datetime.date.fromisoformat(init_str)
+            except ValueError:
+                raise ValueError(f"Cannot convert string to {value_type}: {init_str}")
+                return None
+            else:
+                _LOGGER.debug(f"[value_to_type] date value: |{value_date}|")
+                return value_date
+
+    elif value_type == "datetime":
+        if init_str is None:
+            return None
+        else:
+            try:
+                value_datetime = datetime.datetime.fromisoformat(init_str)
+            except ValueError:
+                raise ValueError(f"Cannot convert string to {value_type}: {init_str}")
+                return None
+            else:
+                _LOGGER.debug(f"[value_to_type] datetime value: |{value_datetime}|")
+                return value_datetime
+
+    elif value_type == "number":
+        if init_str is None:
+            return None
+        elif (value_num := to_num(init_str)) is not None:
+            _LOGGER.debug(f"[value_to_type] number value: |{value_num}|")
+            return value_num
+        else:
+            raise ValueError(f"Cannot convert string to {value_type}: {init_str}")
+    elif value_type == "string":
+        _LOGGER.debug(f"[value_to_type] stringvalue: |{init_str}|")
+        return init_str
+    else:
+        raise ValueError(f"Invalid value_type: {value_type}")
+        return None

--- a/custom_components/variable/manifest.json
+++ b/custom_components/variable/manifest.json
@@ -1,6 +1,7 @@
 {
     "domain": "variable",
     "name": "Variables+History",
+    "after_dependencies": ["recorder"],
     "codeowners": [
         "@rogro82",
         "@wibias",

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -1,5 +1,6 @@
 import logging
 
+from homeassistant.components.recorder import DATA_INSTANCE as RECORDER_INSTANCE
 from homeassistant.components.sensor import PLATFORM_SCHEMA, RestoreSensor
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ICON, CONF_NAME, Platform
@@ -14,11 +15,13 @@ from .const import (
     ATTR_REPLACE_ATTRIBUTES,
     ATTR_VALUE,
     CONF_ATTRIBUTES,
+    CONF_EXCLUDE_FROM_RECORDER,
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
     CONF_VALUE,
     CONF_VARIABLE_ID,
     CONF_YAML_VARIABLE,
+    DEFAULT_EXCLUDE_FROM_RECORDER,
     DEFAULT_FORCE_UPDATE,
     DEFAULT_ICON,
     DEFAULT_REPLACE_ATTRIBUTES,
@@ -40,6 +43,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_ATTRIBUTES): dict,
         vol.Optional(CONF_RESTORE, default=DEFAULT_RESTORE): cv.boolean,
         vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
+        vol.Optional(
+            CONF_EXCLUDE_FROM_RECORDER, default=DEFAULT_EXCLUDE_FROM_RECORDER
+        ): cv.boolean,
     }
 )
 
@@ -112,9 +118,23 @@ class Variable(RestoreSensor):
         self._restore = config.get(CONF_RESTORE)
         self._force_update = config.get(CONF_FORCE_UPDATE)
         self._yaml_variable = config.get(CONF_YAML_VARIABLE)
+        self._exclude_from_recorder = config.get(CONF_EXCLUDE_FROM_RECORDER)
         self.entity_id = generate_entity_id(
             ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
         )
+        if self._exclude_from_recorder:
+            self.disable_recorder()
+
+    def disable_recorder(self):
+        if RECORDER_INSTANCE in self._hass.data:
+            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
+            _LOGGER.info(f"({self._attr_name}) [disable_recorder] Disabling Recorder")
+            if self.entity_id:
+                ha_history_recorder.entity_filter._exclude_e.add(self.entity_id)
+
+            _LOGGER.debug(
+                f"({self._attr_name}) [disable_recorder] _exclude_e: {ha_history_recorder.entity_filter._exclude_e}"
+            )
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""
@@ -146,6 +166,16 @@ class Variable(RestoreSensor):
                         f"native_value: {sensor.native_value} | state: {state.state}"
                     )
                     self._attr_native_value = state.state
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        if RECORDER_INSTANCE in self._hass.data:
+            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
+            if self.entity_id:
+                _LOGGER.debug(
+                    f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
+                )
+                ha_history_recorder.entity_filter._exclude_e.discard(self.entity_id)
 
     @property
     def should_poll(self):

--- a/custom_components/variable/strings.json
+++ b/custom_components/variable/strings.json
@@ -16,7 +16,8 @@
           "value": "Initial Value",
           "attributes": "Initial Attributes",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Sensor Variable"
       },
@@ -29,7 +30,8 @@
           "value": "Initial Value",
           "attributes": "Initial Attributes",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Binary Sensor Variable"
       }
@@ -44,7 +46,8 @@
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Update existing Variable Sensor"
       },
@@ -54,7 +57,8 @@
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Update existing Variable Binary Sensor"
       }

--- a/custom_components/variable/strings.json
+++ b/custom_components/variable/strings.json
@@ -13,13 +13,22 @@
           "name": "[%key:common::config_flow::data::name%]",
           "variable_id": "Variable ID",
           "icon": "Icon",
-          "value": "Initial Value",
-          "attributes": "Initial Attributes",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Sensor Variable"
+      },
+      "sensor_page_2": {
+        "title": "Variables+History - Sensor Page 2",
+        "data": {
+          "value": "Initial Value",
+          "attributes": "Initial Attributes",
+          "state_class": "State Class",
+          "unit_of_measurement": "Unit of Measurement"
+        },
+        "description": "Create a new Sensor Variable Page 2"
       },
       "add_binary_sensor": {
         "title": "Variables+History - Binary Sensor",
@@ -29,12 +38,17 @@
           "icon": "Icon",
           "value": "Initial Value",
           "attributes": "Initial Attributes",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Binary Sensor Variable"
       }
+    },
+    "error": {
+      "invalid_value_type": "The value entered is not compatible with the selected device_class",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   },
   "options": {
@@ -43,11 +57,20 @@
       "sensor_options": {
         "title": "Variables+History - Sensor",
         "data": {
-          "value": "Value (typically only useful if Restore on Restart is False)",
-          "attributes": "Attributes (typically only useful if Restore on Restart is False)",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
+        },
+        "description": "Update existing Variable Sensor"
+      },
+      "sensor_options_page_2": {
+        "title": "Variables+History - Sensor Page 2",
+        "data": {
+          "value": "Value (typically only useful if Restore on Restart is False)",
+          "attributes": "Attributes (typically only useful if Restore on Restart is False)",
+          "state_class": "State Class",
+          "unit_of_measurement": "Unit of Measurement"
         },
         "description": "Update existing Variable Sensor"
       },
@@ -56,12 +79,17 @@
         "data": {
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Update existing Variable Binary Sensor"
       }
+    },
+    "error": {
+      "invalid_value_type": "The value entered is not compatible with the selected device_class",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
       "yaml_variable": "Cannot change options here for Variables created by YAML.\n\nTo use the User Interface to manage this Variable, you will need to:\n1. Remove it from YAML\n2. Delete the imported Variable entity from Home Assistant\n3. Restart Home Assistant\n4. Manually recreate it in Home Assistant, Integrations, +Add Integration.",

--- a/custom_components/variable/translations/en.json
+++ b/custom_components/variable/translations/en.json
@@ -13,13 +13,22 @@
           "name": "Variable Name",
           "variable_id": "Variable ID",
           "icon": "Icon",
-          "value": "Initial Value",
-          "attributes": "Initial Attributes",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Sensor Variable\nSee [Configuration Options]({component_config_url}) on GitHub for details"
+      },
+      "sensor_page_2": {
+        "title": "Variables+History - Sensor Page 2",
+        "data": {
+          "value": "Initial Value",
+          "attributes": "Initial Attributes",
+          "state_class": "State Class",
+          "unit_of_measurement": "Unit of Measurement"
+        },
+        "description": "Create a new Sensor Variable Page 2\n\n**Variable:&nbsp;{disp_name}**\n**Device Class:&nbsp;{device_class}**\n**Value Type:&nbsp;{value_type}**"
       },
       "add_binary_sensor": {
         "title": "Variables+History - Binary Sensor",
@@ -29,12 +38,17 @@
           "icon": "Icon",
           "value": "Initial Value",
           "attributes": "Initial Attributes",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Binary Sensor Variable\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       }
+    },
+    "error": {
+      "invalid_value_type": "The value entered is not compatible with the selected device_class: {device_class}. Expected {value_type}.",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   },
   "options": {
@@ -43,25 +57,39 @@
       "sensor_options": {
         "title": "Variables+History - Sensor",
         "data": {
-          "value": "Value (typically only useful if Restore on Restart is False)",
-          "attributes": "Attributes (typically only useful if Restore on Restart is False)",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
         },
-        "description": "**Updating Sensor:&nbsp;{entity_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
+        "description": "**Updating Sensor:&nbsp;{disp_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
+      },
+      "sensor_options_page_2": {
+        "title": "Variables+History - Sensor Page 2",
+        "data": {
+          "value": "Value (typically only useful if Restore on Restart is False)",
+          "attributes": "Attributes (typically only useful if Restore on Restart is False)",
+          "state_class": "State Class",
+          "unit_of_measurement": "Unit of Measurement"
+        },
+        "description": "Updating Sensor Variable Page 2\n\n**Variable:&nbsp;{disp_name}**\n**Device Class:&nbsp;{device_class}**\n**Value Type:&nbsp;{value_type}**"
       },
       "binary_sensor_options": {
         "title": "Variables+History - Binary Sensor",
         "data": {
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
         },
-        "description": "**Updating Binary Sensor:&nbsp;{entity_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
+        "description": "**Updating Binary Sensor:&nbsp;{disp_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       }
+    },
+    "error": {
+      "invalid_value_type": "The value entered is not compatible with the selected device_class: {device_class}. Expected {value_type}.",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
       "yaml_variable": "Cannot change options here for Variables created by YAML.\n\nTo use the User Interface to manage this Variable, you will need to:\n1. Remove it from YAML\n2. Delete the imported Variable entity from Home Assistant\n3. Restart Home Assistant\n4. Manually recreate it in Home Assistant, Integrations, +Add Integration.",

--- a/custom_components/variable/translations/en.json
+++ b/custom_components/variable/translations/en.json
@@ -16,7 +16,8 @@
           "value": "Initial Value",
           "attributes": "Initial Attributes",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Sensor Variable\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       },
@@ -29,7 +30,8 @@
           "value": "Initial Value",
           "attributes": "Initial Attributes",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Binary Sensor Variable\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       }
@@ -44,7 +46,8 @@
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "**Updating Sensor:&nbsp;{entity_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       },
@@ -54,7 +57,8 @@
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "**Updating Binary Sensor:&nbsp;{entity_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       }


### PR DESCRIPTION
For variables with large attributes, the event recorder will give a Warning if the attributes is >16kB. This gives an option in both the UI and in yaml exclude the variable from the recorder.

Fixes #40 