### PR TITLE
Option to exclude from recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Name | Required | Default | Description |
 `Initial Attributes` | `No` | | Initial attributes of the variable. If `Restore on Restart` is `False`, the variable will reset to this value on every restart
 `Restore on Restart` | `No` | `True` | If `True` will restore previous value on restart. If `False`, will reset to `Initial Value` and `Initial Attributes` on restart
 `Force Update` | `No` | `False` | Variable's `last_updated` time will change with any service calls to update the variable even if the value does not change
+`Exclude from Recorder` | `No` | `False` | For Variables with large attributes (>16 kB), enable this to prevent Recorder Errors.
 
 </details>
 
@@ -78,6 +79,7 @@ Name | Required | Default | Description |
 `Initial Attributes` | `No` | | Initial attributes of the variable. If `Restore on Restart` is `False`, the variable will reset to this value on every restart
 `Restore on Restart` | `No` | `True` | If `True` will restore previous value on restart. If `False`, will reset to `Initial Value` and `Initial Attributes` on restart
 `Force Update` | `No` | `False` | Variable's `last_updated` time will change with any service calls to update the variable even if the value does not change
+`Exclude from Recorder` | `No` | `False` | For Variables with large attributes (>16 kB), enable this to prevent Recorder Errors.
 
 </details>
 
@@ -98,6 +100,7 @@ Initial Value | `value` | `No` | | Initial value/state of the variable. If `Rest
 Initial Attributes | `attributes` | `No` | | Initial attributes of the variable. If `Restore on Restart` is `False`, the variable will reset to this value on every restart
 Restore on Restart | `restore` | `No` | `True` | If `True` will restore previous value on restart. If `False`, will reset to `Initial Value` and `Initial Attributes` on restart
 Force Update | `force_update` | `No` | `False` | Variable's `last_updated` time will change with any service calls to update the variable even if the value does not change
+Exclude from Recorder | `exclude_from_recorder` | `No` | `False` | For Variables with large attributes (>16 kB), set to `True` to prevent Recorder Errors.  
 
 #### Example:
 

--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -1,6 +1,7 @@
 import logging
 
 from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorEntity
+from homeassistant.components.recorder import DATA_INSTANCE as RECORDER_INSTANCE
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ICON, CONF_NAME, STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
@@ -15,11 +16,13 @@ from .const import (
     ATTR_REPLACE_ATTRIBUTES,
     ATTR_VALUE,
     CONF_ATTRIBUTES,
+    CONF_EXCLUDE_FROM_RECORDER,
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
     CONF_VALUE,
     CONF_VARIABLE_ID,
     CONF_YAML_VARIABLE,
+    DEFAULT_EXCLUDE_FROM_RECORDER,
     DEFAULT_FORCE_UPDATE,
     DEFAULT_ICON,
     DEFAULT_REPLACE_ATTRIBUTES,
@@ -41,6 +44,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_ATTRIBUTES): dict,
         vol.Optional(CONF_RESTORE, default=DEFAULT_RESTORE): cv.boolean,
         vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
+        vol.Optional(
+            CONF_EXCLUDE_FROM_RECORDER, default=DEFAULT_EXCLUDE_FROM_RECORDER
+        ): cv.boolean,
     }
 )
 
@@ -118,9 +124,23 @@ class Variable(BinarySensorEntity, RestoreEntity):
         self._restore = config.get(CONF_RESTORE)
         self._force_update = config.get(CONF_FORCE_UPDATE)
         self._yaml_variable = config.get(CONF_YAML_VARIABLE)
+        self._exclude_from_recorder = config.get(CONF_EXCLUDE_FROM_RECORDER)
         self.entity_id = generate_entity_id(
             ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
         )
+        if self._exclude_from_recorder:
+            self.disable_recorder()
+
+    def disable_recorder(self):
+        if RECORDER_INSTANCE in self._hass.data:
+            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
+            _LOGGER.info(f"({self._attr_name}) [disable_recorder] Disabling Recorder")
+            if self.entity_id:
+                ha_history_recorder.entity_filter._exclude_e.add(self.entity_id)
+
+            _LOGGER.debug(
+                f"({self._attr_name}) [disable_recorder] _exclude_e: {ha_history_recorder.entity_filter._exclude_e}"
+            )
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""
@@ -137,6 +157,16 @@ class Variable(BinarySensorEntity, RestoreEntity):
                     self._attr_is_on = True
                 else:
                     self._attr_is_on = state.state
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        if RECORDER_INSTANCE in self._hass.data:
+            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
+            if self.entity_id:
+                _LOGGER.debug(
+                    f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
+                )
+                ha_history_recorder.entity_filter._exclude_e.discard(self.entity_id)
 
     @property
     def should_poll(self):

--- a/custom_components/variable/config_flow.py
+++ b/custom_components/variable/config_flow.py
@@ -14,11 +14,13 @@ import voluptuous as vol
 from .const import (
     CONF_ATTRIBUTES,
     CONF_ENTITY_PLATFORM,
+    CONF_EXCLUDE_FROM_RECORDER,
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
     CONF_VALUE,
     CONF_VARIABLE_ID,
     CONF_YAML_VARIABLE,
+    DEFAULT_EXCLUDE_FROM_RECORDER,
     DEFAULT_FORCE_UPDATE,
     DEFAULT_ICON,
     DEFAULT_RESTORE,
@@ -51,6 +53,9 @@ ADD_SENSOR_SCHEMA = vol.Schema(
         vol.Optional(
             CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE
         ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+        vol.Optional(
+            CONF_EXCLUDE_FROM_RECORDER, default=DEFAULT_EXCLUDE_FROM_RECORDER
+        ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
     }
 )
 
@@ -78,6 +83,9 @@ ADD_BINARY_SENSOR_SCHEMA = vol.Schema(
         ),
         vol.Optional(
             CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE
+        ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+        vol.Optional(
+            CONF_EXCLUDE_FROM_RECORDER, default=DEFAULT_EXCLUDE_FROM_RECORDER
         ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
     }
 )
@@ -251,6 +259,12 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_FORCE_UPDATE, DEFAULT_FORCE_UPDATE
                     ),
                 ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+                vol.Optional(
+                    CONF_EXCLUDE_FROM_RECORDER,
+                    default=self.config_entry.data.get(
+                        CONF_EXCLUDE_FROM_RECORDER, DEFAULT_EXCLUDE_FROM_RECORDER
+                    ),
+                ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
             }
         )
 
@@ -307,6 +321,12 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_FORCE_UPDATE,
                     default=self.config_entry.data.get(
                         CONF_FORCE_UPDATE, DEFAULT_FORCE_UPDATE
+                    ),
+                ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+                vol.Optional(
+                    CONF_EXCLUDE_FROM_RECORDER,
+                    default=self.config_entry.data.get(
+                        CONF_EXCLUDE_FROM_RECORDER, DEFAULT_EXCLUDE_FROM_RECORDER
                     ),
                 ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
             }

--- a/custom_components/variable/const.py
+++ b/custom_components/variable/const.py
@@ -9,6 +9,7 @@ DEFAULT_FORCE_UPDATE = False
 DEFAULT_ICON = "mdi:variable"
 DEFAULT_REPLACE_ATTRIBUTES = False
 DEFAULT_RESTORE = True
+DEFAULT_EXCLUDE_FROM_RECORDER = False
 
 CONF_ATTRIBUTES = "attributes"
 CONF_ENTITY_PLATFORM = "entity_platform"
@@ -17,6 +18,7 @@ CONF_RESTORE = "restore"
 CONF_VALUE = "value"
 CONF_VARIABLE_ID = "variable_id"
 CONF_YAML_VARIABLE = "yaml_variable"
+CONF_EXCLUDE_FROM_RECORDER = "exclude_from_recorder"
 
 ATTR_ATTRIBUTES = "attributes"
 ATTR_ENTITY = "entity"

--- a/custom_components/variable/manifest.json
+++ b/custom_components/variable/manifest.json
@@ -1,6 +1,7 @@
 {
     "domain": "variable",
     "name": "Variables+History",
+    "after_dependencies": ["recorder"],
     "codeowners": [
         "@rogro82",
         "@wibias",

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -1,5 +1,6 @@
 import logging
 
+from homeassistant.components.recorder import DATA_INSTANCE as RECORDER_INSTANCE
 from homeassistant.components.sensor import PLATFORM_SCHEMA, RestoreSensor
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ICON, CONF_NAME, Platform
@@ -14,11 +15,13 @@ from .const import (
     ATTR_REPLACE_ATTRIBUTES,
     ATTR_VALUE,
     CONF_ATTRIBUTES,
+    CONF_EXCLUDE_FROM_RECORDER,
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
     CONF_VALUE,
     CONF_VARIABLE_ID,
     CONF_YAML_VARIABLE,
+    DEFAULT_EXCLUDE_FROM_RECORDER,
     DEFAULT_FORCE_UPDATE,
     DEFAULT_ICON,
     DEFAULT_REPLACE_ATTRIBUTES,
@@ -40,6 +43,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_ATTRIBUTES): dict,
         vol.Optional(CONF_RESTORE, default=DEFAULT_RESTORE): cv.boolean,
         vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
+        vol.Optional(
+            CONF_EXCLUDE_FROM_RECORDER, default=DEFAULT_EXCLUDE_FROM_RECORDER
+        ): cv.boolean,
     }
 )
 
@@ -112,9 +118,23 @@ class Variable(RestoreSensor):
         self._restore = config.get(CONF_RESTORE)
         self._force_update = config.get(CONF_FORCE_UPDATE)
         self._yaml_variable = config.get(CONF_YAML_VARIABLE)
+        self._exclude_from_recorder = config.get(CONF_EXCLUDE_FROM_RECORDER)
         self.entity_id = generate_entity_id(
             ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
         )
+        if self._exclude_from_recorder:
+            self.disable_recorder()
+
+    def disable_recorder(self):
+        if RECORDER_INSTANCE in self._hass.data:
+            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
+            _LOGGER.info(f"({self._attr_name}) [disable_recorder] Disabling Recorder")
+            if self.entity_id:
+                ha_history_recorder.entity_filter._exclude_e.add(self.entity_id)
+
+            _LOGGER.debug(
+                f"({self._attr_name}) [disable_recorder] _exclude_e: {ha_history_recorder.entity_filter._exclude_e}"
+            )
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""
@@ -146,6 +166,16 @@ class Variable(RestoreSensor):
                         f"native_value: {sensor.native_value} | state: {state.state}"
                     )
                     self._attr_native_value = state.state
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        if RECORDER_INSTANCE in self._hass.data:
+            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
+            if self.entity_id:
+                _LOGGER.debug(
+                    f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
+                )
+                ha_history_recorder.entity_filter._exclude_e.discard(self.entity_id)
 
     @property
     def should_poll(self):

--- a/custom_components/variable/strings.json
+++ b/custom_components/variable/strings.json
@@ -16,7 +16,8 @@
           "value": "Initial Value",
           "attributes": "Initial Attributes",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Sensor Variable"
       },
@@ -29,7 +30,8 @@
           "value": "Initial Value",
           "attributes": "Initial Attributes",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Binary Sensor Variable"
       }
@@ -44,7 +46,8 @@
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Update existing Variable Sensor"
       },
@@ -54,7 +57,8 @@
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Update existing Variable Binary Sensor"
       }

--- a/custom_components/variable/translations/en.json
+++ b/custom_components/variable/translations/en.json
@@ -16,7 +16,8 @@
           "value": "Initial Value",
           "attributes": "Initial Attributes",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Sensor Variable\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       },
@@ -29,7 +30,8 @@
           "value": "Initial Value",
           "attributes": "Initial Attributes",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Binary Sensor Variable\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       }
@@ -44,7 +46,8 @@
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "**Updating Sensor:&nbsp;{entity_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       },
@@ -54,7 +57,8 @@
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
           "restore": "Restore on Restart",
-          "force_update": "Force Update"
+          "force_update": "Force Update",
+          "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "**Updating Binary Sensor:&nbsp;{entity_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       }


### PR DESCRIPTION
_Sorry. Having some GitHub Branch issues. Trying again._

For variables with large attributes, the event recorder will give a Warning if the attributes is >16kB. This gives an option in both the UI and in yaml exclude the variable from the recorder.

Fixes #40 