### PR TITLE
Handle Disable Recorder AttributeError in 2023.6+

### DIFF
--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -157,11 +157,16 @@ class Variable(BinarySensorEntity, RestoreEntity):
             ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
             _LOGGER.info(f"({self._attr_name}) [disable_recorder] Disabling Recorder")
             if self.entity_id:
-                ha_history_recorder.entity_filter._exclude_e.add(self.entity_id)
-
-            _LOGGER.debug(
-                f"({self._attr_name}) [disable_recorder] _exclude_e: {ha_history_recorder.entity_filter._exclude_e}"
-            )
+                try:
+                    ha_history_recorder.entity_filter._exclude_e.add(self.entity_id)
+                except AttributeError as e:
+                    _LOGGER.warning(
+                        f"({self._attr_name}) [disable_recorder] AttributeError trying to disable Recorder: {e}"
+                    )
+                else:
+                    _LOGGER.debug(
+                        f"({self._attr_name}) [disable_recorder] _exclude_e: {ha_history_recorder.entity_filter._exclude_e}"
+                    )
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -148,11 +148,16 @@ class Variable(RestoreSensor):
             ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
             _LOGGER.info(f"({self._attr_name}) [disable_recorder] Disabling Recorder")
             if self.entity_id:
-                ha_history_recorder.entity_filter._exclude_e.add(self.entity_id)
-
-            _LOGGER.debug(
-                f"({self._attr_name}) [disable_recorder] _exclude_e: {ha_history_recorder.entity_filter._exclude_e}"
-            )
+                try:
+                    ha_history_recorder.entity_filter._exclude_e.add(self.entity_id)
+                except AttributeError as e:
+                    _LOGGER.warning(
+                        f"({self._attr_name}) [disable_recorder] AttributeError trying to disable Recorder: {e}"
+                    )
+                else:
+                    _LOGGER.debug(
+                        f"({self._attr_name}) [disable_recorder] _exclude_e: {ha_history_recorder.entity_filter._exclude_e}"
+                    )
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""


### PR DESCRIPTION
Note that Disable Recorder won't actually work in 2023.6+ with this fix, it just allows it to fail gracefully and the integration will continue to work. I plan to fix Disable Recorder once a fix is identified.