### PR TITLE
Add device class and unit of measurement

### DIFF
--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -221,7 +221,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
                         entry, data=var_fields, options=entry.options
                     )
 
-                    hass.config_entries.async_reload(entry_id)
+                    await hass.config_entries.async_reload(entry_id)
 
                 else:
                     _LOGGER.error(

--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -221,7 +221,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
                         entry, data=var_fields, options=entry.options
                     )
 
-                    await hass.config_entries.async_reload(entry_id)
+                    hass.config_entries.async_reload(entry_id)
 
                 else:
                     _LOGGER.error(

--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     ATTR_ICON,
+    CONF_DEVICE_CLASS,
     CONF_ICON,
     CONF_NAME,
     STATE_OFF,
@@ -15,7 +16,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers import config_validation as cv, entity_platform, selector
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import slugify
@@ -79,7 +80,15 @@ async def async_setup_entry(
     platform.async_register_entity_service(
         SERVICE_UPDATE_VARIABLE,
         {
-            vol.Optional(ATTR_VALUE): cv.boolean,
+            vol.Optional(CONF_VALUE): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=["None", "true", "false"],
+                    translation_key="boolean_options",
+                    multiple=False,
+                    custom_value=False,
+                    mode=selector.SelectSelectorMode.LIST,
+                )
+            ),
             vol.Optional(ATTR_ATTRIBUTES): dict,
             vol.Optional(
                 ATTR_REPLACE_ATTRIBUTES, default=DEFAULT_REPLACE_ATTRIBUTES
@@ -113,13 +122,16 @@ class Variable(BinarySensorEntity, RestoreEntity):
         _LOGGER.debug(
             f"({config.get(CONF_NAME, config.get(CONF_VARIABLE_ID))}) [init] config: {config}"
         )
-        if config.get(CONF_VALUE):
-            if config.get(CONF_VALUE).lower() in ["true", "1", "t", "y", "yes", "on"]:
-                bool_val = True
-            else:
-                bool_val = False
-        else:
+        if config.get(CONF_VALUE) is None or config.get(CONF_VALUE) in [
+            "None",
+            "unknown",
+            "unavailable",
+        ]:
             bool_val = None
+        elif config.get(CONF_VALUE).lower() in ["true", "1", "t", "y", "yes", "on"]:
+            bool_val = True
+        else:
+            bool_val = False
         self._hass = hass
         self._config = config
         self._config_entry = config_entry
@@ -132,6 +144,7 @@ class Variable(BinarySensorEntity, RestoreEntity):
             self._attr_name = config.get(CONF_VARIABLE_ID)
         self._attr_icon = config.get(CONF_ICON)
         self._attr_is_on = bool_val
+        self._attr_device_class = config.get(CONF_DEVICE_CLASS)
         self._restore = config.get(CONF_RESTORE)
         self._force_update = config.get(CONF_FORCE_UPDATE)
         self._yaml_variable = config.get(CONF_YAML_VARIABLE)
@@ -159,10 +172,8 @@ class Variable(BinarySensorEntity, RestoreEntity):
             if self.entity_id:
                 try:
                     ha_history_recorder.entity_filter._exclude_e.add(self.entity_id)
-                except AttributeError as e:
-                    _LOGGER.warning(
-                        f"({self._attr_name}) [disable_recorder] AttributeError trying to disable Recorder: {e}"
-                    )
+                except AttributeError:
+                    pass
                 else:
                     _LOGGER.debug(
                         f"({self._attr_name}) [disable_recorder] _exclude_e: {ha_history_recorder.entity_filter._exclude_e}"
@@ -185,26 +196,33 @@ class Variable(BinarySensorEntity, RestoreEntity):
                         state.attributes.copy()
                     )
                 if hasattr(state, "state"):
-                    if state.state == STATE_OFF:
+                    if state.state is None or state.state in [
+                        "unknown",
+                        "unavailable",
+                    ]:
+                        self._attr_is_on = None
+                    elif state.state == STATE_OFF:
                         self._attr_is_on = False
                     elif state.state == STATE_ON:
                         self._attr_is_on = True
-                    elif state.state is None:
-                        self._attr_is_on = False
                     else:
                         self._attr_is_on = state.state
                 else:
-                    self._attr_is_on = False
+                    self._attr_is_on = None
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
         if RECORDER_INSTANCE in self._hass.data:
             ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
             if self.entity_id:
-                _LOGGER.debug(
-                    f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
-                )
-                ha_history_recorder.entity_filter._exclude_e.discard(self.entity_id)
+                try:
+                    ha_history_recorder.entity_filter._exclude_e.discard(self.entity_id)
+                except AttributeError:
+                    pass
+                else:
+                    _LOGGER.debug(
+                        f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
+                    )
 
     @property
     def should_poll(self):
@@ -235,16 +253,12 @@ class Variable(BinarySensorEntity, RestoreEntity):
         else:
             return None
 
-    async def async_update_variable(
-        self,
-        value=None,
-        attributes=None,
-        replace_attributes=False,
-    ) -> None:
+    async def async_update_variable(self, **kwargs) -> None:
         """Update Binary Sensor Variable."""
 
         updated_attributes = None
 
+        replace_attributes = kwargs.get(ATTR_REPLACE_ATTRIBUTES, False)
         _LOGGER.debug(
             f"({self._attr_name}) [async_update_variable] Replace Attributes: {replace_attributes}"
         )
@@ -256,6 +270,7 @@ class Variable(BinarySensorEntity, RestoreEntity):
         ):
             updated_attributes = copy.deepcopy(self._attr_extra_state_attributes)
 
+        attributes = kwargs.get(ATTR_ATTRIBUTES)
         if attributes is not None:
             if isinstance(attributes, MutableMapping):
                 _LOGGER.debug(
@@ -279,9 +294,29 @@ class Variable(BinarySensorEntity, RestoreEntity):
         else:
             self._attr_extra_state_attributes = None
 
-        if value is None:
-            self._attr_is_on = False
-        else:
-            self._attr_is_on = value
+        if ATTR_VALUE in kwargs:
+            if kwargs.get(ATTR_VALUE) is None or (
+                isinstance(kwargs.get(ATTR_VALUE), str)
+                and kwargs.get(ATTR_VALUE).lower()
+                in ["", "none", "unknown", "unavailable"]
+            ):
+                self._attr_is_on = None
+            elif isinstance(kwargs.get(ATTR_VALUE), str):
+                if kwargs.get(ATTR_VALUE).lower() in [
+                    "true",
+                    "1",
+                    "t",
+                    "y",
+                    "yes",
+                    "on",
+                ]:
+                    self._attr_is_on = True
+                else:
+                    self._attr_is_on = False
+            else:
+                self._attr_is_on = kwargs.get(ATTR_VALUE)
+            _LOGGER.debug(
+                f"({self._attr_name}) [async_update_variable] New Value: {self._attr_is_on}"
+            )
 
         self.async_write_ha_state()

--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -122,11 +122,10 @@ class Variable(BinarySensorEntity, RestoreEntity):
         _LOGGER.debug(
             f"({config.get(CONF_NAME, config.get(CONF_VARIABLE_ID))}) [init] config: {config}"
         )
-        if config.get(CONF_VALUE) is None or config.get(CONF_VALUE) in [
-            "None",
-            "unknown",
-            "unavailable",
-        ]:
+        if config.get(CONF_VALUE) is None or (
+            isinstance(config.get(CONF_VALUE), str)
+            and config.get(CONF_VALUE).lower() in ["", "none", "unknown", "unavailable"]
+        ):
             bool_val = None
         elif config.get(CONF_VALUE).lower() in ["true", "1", "t", "y", "yes", "on"]:
             bool_val = True
@@ -196,10 +195,11 @@ class Variable(BinarySensorEntity, RestoreEntity):
                         state.attributes.copy()
                     )
                 if hasattr(state, "state"):
-                    if state.state is None or state.state in [
-                        "unknown",
-                        "unavailable",
-                    ]:
+                    if state.state is None or (
+                        isinstance(state.state, str)
+                        and state.state.lower()
+                        in ["", "none", "unknown", "unavailable"]
+                    ):
                         self._attr_is_on = None
                     elif state.state == STATE_OFF:
                         self._attr_is_on = False

--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -126,11 +126,14 @@ class Variable(BinarySensorEntity, RestoreEntity):
             isinstance(config.get(CONF_VALUE), str)
             and config.get(CONF_VALUE).lower() in ["", "none", "unknown", "unavailable"]
         ):
-            bool_val = None
-        elif config.get(CONF_VALUE).lower() in ["true", "1", "t", "y", "yes", "on"]:
-            bool_val = True
+            self._attr_is_on = None
+        elif isinstance(config.get(CONF_VALUE), str):
+            if config.get(CONF_VALUE).lower() in ["true", "1", "t", "y", "yes", "on"]:
+                self._attr_is_on = True
+            else:
+                self._attr_is_on = False
         else:
-            bool_val = False
+            self._attr_is_on = config.get(CONF_VALUE)
         self._hass = hass
         self._config = config
         self._config_entry = config_entry
@@ -142,7 +145,6 @@ class Variable(BinarySensorEntity, RestoreEntity):
         else:
             self._attr_name = config.get(CONF_VARIABLE_ID)
         self._attr_icon = config.get(CONF_ICON)
-        self._attr_is_on = bool_val
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)
         self._restore = config.get(CONF_RESTORE)
         self._force_update = config.get(CONF_FORCE_UPDATE)

--- a/custom_components/variable/config_flow.py
+++ b/custom_components/variable/config_flow.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
+from enum import Enum
 import logging
 from typing import Any
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_ICON, CONF_NAME, Platform
+from homeassistant.components import binary_sensor, sensor
+from homeassistant.const import (
+    CONF_DEVICE_CLASS,
+    CONF_ICON,
+    CONF_NAME,
+    CONF_UNIT_OF_MEASUREMENT,
+    Platform,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
 import homeassistant.helpers.config_validation as cv
+from iso4217 import Currency
 import voluptuous as vol
 
 from .const import (
@@ -18,6 +27,7 @@ from .const import (
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
     CONF_VALUE,
+    CONF_VALUE_TYPE,
     CONF_VARIABLE_ID,
     CONF_YAML_VARIABLE,
     DEFAULT_EXCLUDE_FROM_RECORDER,
@@ -27,6 +37,7 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
+from .helpers import value_to_type
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,6 +47,25 @@ COMPONENT_CONFIG_URL = "https://github.com/Wibias/hass-variables"
 # translations/<lang>.json file and strings.json. See here for further information:
 # https://developers.home-assistant.io/docs/config_entries_config_flow_handler/#translations
 
+SENSOR_DEVICE_CLASS_SELECT_LIST = []
+SENSOR_DEVICE_CLASS_SELECT_LIST.append(
+    selector.SelectOptionDict(label="None", value="None")
+)
+for el in sensor.SensorDeviceClass:
+    if el != sensor.SensorDeviceClass.ENUM:
+        SENSOR_DEVICE_CLASS_SELECT_LIST.append(
+            selector.SelectOptionDict(label=str(el.name), value=str(el.value))
+        )
+
+BINARY_SENSOR_DEVICE_CLASS_SELECT_LIST = []
+BINARY_SENSOR_DEVICE_CLASS_SELECT_LIST.append(
+    selector.SelectOptionDict(label="None", value="None")
+)
+for el in binary_sensor.BinarySensorDeviceClass:
+    BINARY_SENSOR_DEVICE_CLASS_SELECT_LIST.append(
+        selector.SelectOptionDict(label=str(el.name), value=str(el.value))
+    )
+
 ADD_SENSOR_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_VARIABLE_ID): cv.string,
@@ -43,9 +73,13 @@ ADD_SENSOR_SCHEMA = vol.Schema(
         vol.Optional(CONF_ICON, default=DEFAULT_ICON): selector.IconSelector(
             selector.IconSelectorConfig()
         ),
-        vol.Optional(CONF_VALUE): cv.string,
-        vol.Optional(CONF_ATTRIBUTES): selector.ObjectSelector(
-            selector.ObjectSelectorConfig()
+        vol.Optional(CONF_DEVICE_CLASS): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=SENSOR_DEVICE_CLASS_SELECT_LIST,
+                multiple=False,
+                custom_value=False,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )
         ),
         vol.Optional(CONF_RESTORE, default=DEFAULT_RESTORE): selector.BooleanSelector(
             selector.BooleanSelectorConfig()
@@ -66,9 +100,9 @@ ADD_BINARY_SENSOR_SCHEMA = vol.Schema(
         vol.Optional(CONF_ICON, default=DEFAULT_ICON): selector.IconSelector(
             selector.IconSelectorConfig()
         ),
-        vol.Optional(CONF_VALUE): selector.SelectSelector(
+        vol.Optional(CONF_VALUE, default="None"): selector.SelectSelector(
             selector.SelectSelectorConfig(
-                options=["true", "false"],
+                options=["None", "true", "false"],
                 translation_key="boolean_options",
                 multiple=False,
                 custom_value=False,
@@ -77,6 +111,14 @@ ADD_BINARY_SENSOR_SCHEMA = vol.Schema(
         ),
         vol.Optional(CONF_ATTRIBUTES): selector.ObjectSelector(
             selector.ObjectSelectorConfig()
+        ),
+        vol.Optional(CONF_DEVICE_CLASS): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=BINARY_SENSOR_DEVICE_CLASS_SELECT_LIST,
+                multiple=False,
+                custom_value=False,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )
         ),
         vol.Optional(CONF_RESTORE, default=DEFAULT_RESTORE): selector.BooleanSelector(
             selector.BooleanSelectorConfig()
@@ -118,21 +160,11 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input=None, errors=None, yaml_variable=False
     ):
         if user_input is not None:
-
-            try:
-                user_input.update({CONF_ENTITY_PLATFORM: Platform.SENSOR})
-                user_input.update({CONF_YAML_VARIABLE: yaml_variable})
-                info = await validate_sensor_input(self.hass, user_input)
-                _LOGGER.debug(f"[New Sensor Variable] info: {info}")
-                _LOGGER.debug(f"[New Sensor Variable] user_input: {user_input}")
-                return self.async_create_entry(
-                    title=info.get("title", ""), data=user_input
-                )
-            except Exception as err:
-                _LOGGER.exception(
-                    f"[config_flow async_step_add_sensor] Unexpected exception: {err}"
-                )
-                errors["base"] = "unknown"
+            user_input.update({CONF_ENTITY_PLATFORM: Platform.SENSOR})
+            user_input.update({CONF_YAML_VARIABLE: yaml_variable})
+            _LOGGER.debug(f"[New Sensor Variable] page_1_input: {user_input}")
+            self.add_sensor_input = user_input
+            return await self.async_step_sensor_page_2()
 
         # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
         return self.async_show_form(
@@ -144,6 +176,200 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
+    async def async_step_sensor_page_2(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            _LOGGER.debug(f"[New Sensor Page 2] page_1_input: {self.add_sensor_input}")
+            _LOGGER.debug(f"[New Sensor Page 2] page_2_input: {user_input}")
+
+            try:
+                newval = value_to_type(
+                    user_input.get(CONF_VALUE),
+                    self.add_sensor_input.get(CONF_VALUE_TYPE),
+                )
+            except ValueError:
+                errors["base"] = "invalid_value_type"
+            else:
+                user_input[CONF_VALUE] = newval
+
+            _LOGGER.debug(
+                f"[New Sensor Page 2] value_type: {self.add_sensor_input.get(CONF_VALUE_TYPE)}"
+            )
+            _LOGGER.debug(
+                f"[New Sensor Page 2] type of value: {type(user_input.get(CONF_VALUE))}"
+            )
+
+            if not errors:
+                if self.add_sensor_input is not None and self.add_sensor_input:
+                    user_input.update(self.add_sensor_input)
+                if user_input is not None:
+                    for k, v in list(user_input.items()):
+                        if v is None or (isinstance(v, str) and v.lower() == "none"):
+                            user_input.pop(k, None)
+                _LOGGER.debug(f"[New Sensor Page 2] Final user_input: {user_input}")
+                info = await validate_sensor_input(self.hass, user_input)
+                return self.async_create_entry(
+                    title=info.get("title", ""), data=user_input
+                )
+
+        _LOGGER.debug(f"[New Sensor Page 2] Initial user_input: {user_input}")
+        _LOGGER.debug(
+            f"[New Sensor Page 2] device_class: {self.add_sensor_input.get(CONF_DEVICE_CLASS)}"
+        )
+
+        SENSOR_PAGE_2_SCHEMA = self.build_add_sensor_page_2()
+
+        if self.add_sensor_input.get(CONF_NAME) is None or self.add_sensor_input.get(
+            CONF_NAME
+        ) == self.add_sensor_input.get(CONF_VARIABLE_ID):
+            disp_name = self.add_sensor_input.get(CONF_VARIABLE_ID)
+        else:
+            disp_name = f"{self.add_sensor_input.get(CONF_NAME)} ({self.add_sensor_input.get(CONF_VARIABLE_ID)})"
+        # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
+        return self.async_show_form(
+            step_id="sensor_page_2",
+            data_schema=SENSOR_PAGE_2_SCHEMA,
+            errors=errors,
+            description_placeholders={
+                "device_class": self.add_sensor_input.get(CONF_DEVICE_CLASS, "None"),
+                "disp_name": disp_name,
+                "value_type": self.add_sensor_input.get(CONF_VALUE_TYPE, "None"),
+            },
+        )
+
+    def build_add_sensor_page_2(self):
+        SENSOR_STATE_CLASS_SELECT_LIST = []
+        SENSOR_STATE_CLASS_SELECT_LIST.append(
+            selector.SelectOptionDict(label="None", value="None")
+        )
+        SENSOR_UNITS_SELECT_LIST = []
+        SENSOR_UNITS_SELECT_LIST.append(
+            selector.SelectOptionDict(label="None", value="None")
+        )
+
+        SENSOR_PAGE_2_SCHEMA = vol.Schema({})
+        if (
+            self.add_sensor_input.get(CONF_DEVICE_CLASS) is not None
+            and self.add_sensor_input.get(CONF_DEVICE_CLASS).lower() != "none"
+        ):
+            for el in sensor.DEVICE_CLASS_STATE_CLASSES.get(
+                self.add_sensor_input.get(CONF_DEVICE_CLASS), Enum
+            ):
+                SENSOR_STATE_CLASS_SELECT_LIST.append(
+                    selector.SelectOptionDict(label=str(el.name), value=str(el.value))
+                )
+            if (
+                self.add_sensor_input.get(CONF_DEVICE_CLASS)
+                == sensor.SensorDeviceClass.MONETARY
+            ):
+                for el in Currency:
+                    if el.code not in ["XTS", "XXX"]:
+                        SENSOR_UNITS_SELECT_LIST.append(
+                            selector.SelectOptionDict(
+                                label=f"{el.currency_name} [{el.code}]",
+                                value=str(el.code),
+                            )
+                        )
+            else:
+                for el in sensor.DEVICE_CLASS_UNITS.get(
+                    self.add_sensor_input.get(CONF_DEVICE_CLASS), []
+                ):
+                    if el is not None and el != "None":
+                        SENSOR_UNITS_SELECT_LIST.append(
+                            selector.SelectOptionDict(label=str(el), value=str(el))
+                        )
+            if self.add_sensor_input.get(CONF_DEVICE_CLASS) in [
+                sensor.SensorDeviceClass.DATE
+            ]:
+                SENSOR_PAGE_2_SCHEMA = SENSOR_PAGE_2_SCHEMA.extend(
+                    {
+                        vol.Optional(CONF_VALUE): selector.DateSelector(
+                            selector.DateSelectorConfig()
+                        )
+                    }
+                )
+                value_type = "date"
+            elif self.add_sensor_input.get(CONF_DEVICE_CLASS) in [
+                sensor.SensorDeviceClass.TIMESTAMP
+            ]:
+                SENSOR_PAGE_2_SCHEMA = SENSOR_PAGE_2_SCHEMA.extend(
+                    {
+                        vol.Optional(CONF_VALUE): selector.DateTimeSelector(
+                            selector.DateTimeSelectorConfig()
+                        )
+                    }
+                )
+                value_type = "datetime"
+            else:
+                SENSOR_PAGE_2_SCHEMA = SENSOR_PAGE_2_SCHEMA.extend(
+                    {
+                        vol.Optional(CONF_VALUE): selector.TextSelector(
+                            selector.TextSelectorConfig()
+                        )
+                    }
+                )
+                value_type = "number"
+        else:
+            for el in sensor.SensorStateClass:
+                SENSOR_STATE_CLASS_SELECT_LIST.append(
+                    selector.SelectOptionDict(label=str(el.name), value=str(el.value))
+                )
+
+            SENSOR_PAGE_2_SCHEMA = SENSOR_PAGE_2_SCHEMA.extend(
+                {
+                    vol.Optional(CONF_VALUE): selector.TextSelector(
+                        selector.TextSelectorConfig()
+                    )
+                }
+            )
+            value_type = "string"
+
+        # _LOGGER.debug(
+        #    f"[New Sensor Page 2] SENSOR_STATE_CLASS_SELECT_LIST: {SENSOR_STATE_CLASS_SELECT_LIST}"
+        # )
+        # _LOGGER.debug(
+        #    f"[New Sensor Page 2] SENSOR_UNITS_SELECT_LIST: {SENSOR_UNITS_SELECT_LIST}"
+        # )
+
+        SENSOR_PAGE_2_SCHEMA = SENSOR_PAGE_2_SCHEMA.extend(
+            {
+                vol.Optional(CONF_ATTRIBUTES): selector.ObjectSelector(
+                    selector.ObjectSelectorConfig()
+                )
+            }
+        )
+        if len(SENSOR_STATE_CLASS_SELECT_LIST) > 1:
+            SENSOR_PAGE_2_SCHEMA = SENSOR_PAGE_2_SCHEMA.extend(
+                {
+                    vol.Optional(sensor.CONF_STATE_CLASS): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=SENSOR_STATE_CLASS_SELECT_LIST,
+                            multiple=False,
+                            custom_value=False,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                }
+            )
+
+        if len(SENSOR_UNITS_SELECT_LIST) > 1:
+            SENSOR_PAGE_2_SCHEMA = SENSOR_PAGE_2_SCHEMA.extend(
+                {
+                    vol.Optional(CONF_UNIT_OF_MEASUREMENT): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=SENSOR_UNITS_SELECT_LIST,
+                            multiple=False,
+                            custom_value=False,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                }
+            )
+
+        _LOGGER.debug(f"[New Sensor Page 2] value_type: {value_type}")
+        self.add_sensor_input.update({CONF_VALUE_TYPE: value_type})
+        return SENSOR_PAGE_2_SCHEMA
+
     async def async_step_add_binary_sensor(
         self, user_input=None, errors=None, yaml_variable=False
     ):
@@ -153,8 +379,7 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input.update({CONF_ENTITY_PLATFORM: Platform.BINARY_SENSOR})
                 user_input.update({CONF_YAML_VARIABLE: yaml_variable})
                 info = await validate_sensor_input(self.hass, user_input)
-                _LOGGER.debug(f"[New Binary Sensor Variable] info: {info}")
-                _LOGGER.debug(f"[Sensor Options] updated user_input: {user_input}")
+                _LOGGER.debug(f"[New Binary Sensor] updated user_input: {user_input}")
                 return self.async_create_entry(
                     title=info.get("title", ""), data=user_input
                 )
@@ -228,27 +453,43 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
     ) -> FlowResult:
 
         if user_input is not None:
-            _LOGGER.debug(f"[Sensor Options] user_input: {user_input}")
+            _LOGGER.debug(f"[Sensor Options Page 1] page_1_input: {user_input}")
+            self.sensor_options_page_1 = user_input
+            return await self.async_step_sensor_options_page_2()
 
-            for m in dict(self.config_entry.data).keys():
-                user_input.setdefault(m, self.config_entry.data[m])
-            _LOGGER.debug(f"[Sensor Options] updated user_input: {user_input}")
-            self.config_entry.options = {}
+        SENSOR_OPTIONS_PAGE_1_SCHEMA = self.build_sensor_options_page_1()
 
-            self.hass.config_entries.async_update_entry(
-                self.config_entry, data=user_input, options=self.config_entry.options
-            )
-            await self.hass.config_entries.async_reload(self.config_entry.entry_id)
-            return self.async_create_entry(title="", data=user_input)
+        if self.config_entry.data.get(CONF_NAME) is None or self.config_entry.data.get(
+            CONF_NAME
+        ) == self.config_entry.data.get(CONF_VARIABLE_ID):
+            disp_name = self.config_entry.data.get(CONF_VARIABLE_ID)
+        else:
+            disp_name = f"{self.config_entry.data.get(CONF_NAME)} ({self.config_entry.data.get(CONF_VARIABLE_ID)})"
 
-        SENSOR_OPTIONS_SCHEMA = vol.Schema(
+        return self.async_show_form(
+            step_id="sensor_options",
+            data_schema=SENSOR_OPTIONS_PAGE_1_SCHEMA,
+            errors=errors,
+            description_placeholders={
+                "component_config_url": COMPONENT_CONFIG_URL,
+                "disp_name": disp_name,
+            },
+        )
+
+    def build_sensor_options_page_1(self):
+        return vol.Schema(
             {
                 vol.Optional(
-                    CONF_VALUE, default=self.config_entry.data.get(CONF_VALUE)
-                ): cv.string,
-                vol.Optional(
-                    CONF_ATTRIBUTES, default=self.config_entry.data.get(CONF_ATTRIBUTES)
-                ): selector.ObjectSelector(selector.ObjectSelectorConfig()),
+                    CONF_DEVICE_CLASS,
+                    default=self.config_entry.data.get(CONF_DEVICE_CLASS, "None"),
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=SENSOR_DEVICE_CLASS_SELECT_LIST,
+                        multiple=False,
+                        custom_value=False,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
                 vol.Optional(
                     CONF_RESTORE,
                     default=self.config_entry.data.get(CONF_RESTORE, DEFAULT_RESTORE),
@@ -268,16 +509,294 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
             }
         )
 
+    async def async_step_sensor_options_page_2(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            _LOGGER.debug(f"[Sensor Options Page 2] user_input: {user_input}")
+            try:
+                newval = value_to_type(
+                    user_input.get(CONF_VALUE),
+                    self.sensor_options_page_1.get(CONF_VALUE_TYPE),
+                )
+            except ValueError:
+                errors["base"] = "invalid_value_type"
+            else:
+                user_input[CONF_VALUE] = newval
+
+            _LOGGER.debug(
+                f"[Sensor Options Page 2] value_type: {self.sensor_options_page_1.get(CONF_VALUE_TYPE)}"
+            )
+            _LOGGER.debug(
+                f"[Sensor Options Page 2] type of value: {type(user_input.get(CONF_VALUE))}"
+            )
+
+            if not errors:
+                if (
+                    self.sensor_options_page_1 is not None
+                    and self.sensor_options_page_1
+                ):
+                    user_input.update(self.sensor_options_page_1)
+                for m in dict(self.config_entry.data).keys():
+                    user_input.setdefault(m, self.config_entry.data[m])
+                if user_input is not None:
+                    for k, v in list(user_input.items()):
+                        if v is None or (isinstance(v, str) and v.lower() == "none"):
+                            user_input.pop(k, None)
+                _LOGGER.debug(f"[Sensor Options Page 2] Final user_input: {user_input}")
+                self.config_entry.options = {}
+
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    data=user_input,
+                    options=self.config_entry.options,
+                )
+                await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+                return self.async_create_entry(title="", data=user_input)
+
+        _LOGGER.debug(f"[Sensor Options Page 2] Initial user_input: {user_input}")
+        _LOGGER.debug(
+            f"[Sensor Options Page 2] device_class: {self.sensor_options_page_1.get(CONF_DEVICE_CLASS)}"
+        )
+
+        SENSOR_OPTIONS_PAGE_2_SCHEMA = self.build_sensor_options_page_2()
+
+        if self.config_entry.data.get(CONF_NAME) is None or self.config_entry.data.get(
+            CONF_NAME
+        ) == self.config_entry.data.get(CONF_VARIABLE_ID):
+            disp_name = self.config_entry.data.get(CONF_VARIABLE_ID)
+        else:
+            disp_name = f"{self.config_entry.data.get(CONF_NAME)} ({self.config_entry.data.get(CONF_VARIABLE_ID)})"
+
         return self.async_show_form(
-            step_id="sensor_options",
-            data_schema=SENSOR_OPTIONS_SCHEMA,
+            step_id="sensor_options_page_2",
+            data_schema=SENSOR_OPTIONS_PAGE_2_SCHEMA,
+            errors=errors,
             description_placeholders={
-                "component_config_url": COMPONENT_CONFIG_URL,
-                "entity_name": self.config_entry.data.get(
-                    CONF_NAME, self.config_entry.data.get(CONF_VARIABLE_ID)
+                "disp_name": disp_name,
+                "value_type": self.sensor_options_page_1.get(CONF_VALUE_TYPE, "None"),
+                "device_class": self.sensor_options_page_1.get(
+                    CONF_DEVICE_CLASS, "None"
                 ),
             },
         )
+
+    def check_value_default(self, new_device_class):
+        val_default_value = None
+        if self.config_entry.data.get(CONF_VALUE) is None or (
+            isinstance(self.config_entry.data.get(CONF_VALUE), str)
+            and self.config_entry.data.get(CONF_VALUE).lower() == "none"
+        ):
+            val_default = False
+        elif self.config_entry.data.get(CONF_DEVICE_CLASS) != new_device_class:
+            val_default = False
+        else:
+            val_default = True
+            val_default_value = self.config_entry.data.get(CONF_VALUE)
+        return val_default, val_default_value
+
+    def build_sensor_options_page_2(self):
+        SENSOR_STATE_CLASS_SELECT_LIST = []
+        SENSOR_STATE_CLASS_SELECT_LIST.append(
+            selector.SelectOptionDict(label="None", value="None")
+        )
+        SENSOR_UNITS_SELECT_LIST = []
+        SENSOR_UNITS_SELECT_LIST.append(
+            selector.SelectOptionDict(label="None", value="None")
+        )
+
+        val_default, val_default_value = self.check_value_default(
+            self.sensor_options_page_1.get(CONF_DEVICE_CLASS)
+        )
+
+        SENSOR_OPTIONS_PAGE_2_SCHEMA = vol.Schema({})
+        if (
+            self.sensor_options_page_1.get(CONF_DEVICE_CLASS) is not None
+            and self.sensor_options_page_1.get(CONF_DEVICE_CLASS).lower() != "none"
+        ):
+            for el in sensor.DEVICE_CLASS_STATE_CLASSES.get(
+                self.sensor_options_page_1.get(CONF_DEVICE_CLASS), Enum
+            ):
+                SENSOR_STATE_CLASS_SELECT_LIST.append(
+                    selector.SelectOptionDict(label=str(el.name), value=str(el.value))
+                )
+            if (
+                self.sensor_options_page_1.get(CONF_DEVICE_CLASS)
+                == sensor.SensorDeviceClass.MONETARY
+            ):
+                for el in Currency:
+                    if el.code not in ["XTS", "XXX"]:
+                        SENSOR_UNITS_SELECT_LIST.append(
+                            selector.SelectOptionDict(
+                                label=f"{el.currency_name} [{el.code}]",
+                                value=str(el.code),
+                            )
+                        )
+            else:
+                for el in sensor.DEVICE_CLASS_UNITS.get(
+                    self.sensor_options_page_1.get(CONF_DEVICE_CLASS), []
+                ):
+                    if el is not None and el != "None":
+                        SENSOR_UNITS_SELECT_LIST.append(
+                            selector.SelectOptionDict(label=str(el), value=str(el))
+                        )
+
+            if self.sensor_options_page_1.get(CONF_DEVICE_CLASS) in [
+                sensor.SensorDeviceClass.DATE
+            ]:
+                value_type = "date"
+                if val_default:
+                    SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                        {
+                            vol.Optional(
+                                CONF_VALUE,
+                                default=val_default_value,
+                            ): selector.DateSelector(selector.DateSelectorConfig())
+                        }
+                    )
+                else:
+                    SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                        {
+                            vol.Optional(
+                                CONF_VALUE,
+                            ): selector.DateSelector(selector.DateSelectorConfig())
+                        }
+                    )
+
+            elif self.sensor_options_page_1.get(CONF_DEVICE_CLASS) in [
+                sensor.SensorDeviceClass.TIMESTAMP
+            ]:
+                value_type = "datetime"
+                if val_default:
+                    SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                        {
+                            vol.Optional(
+                                CONF_VALUE,
+                                default=val_default_value,
+                            ): selector.DateTimeSelector(
+                                selector.DateTimeSelectorConfig()
+                            )
+                        }
+                    )
+                else:
+                    SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                        {
+                            vol.Optional(CONF_VALUE,): selector.DateTimeSelector(
+                                selector.DateTimeSelectorConfig()
+                            )
+                        }
+                    )
+            else:
+                value_type = "number"
+                if val_default:
+                    SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                        {
+                            vol.Optional(
+                                CONF_VALUE,
+                                default=str(val_default_value),
+                            ): selector.TextSelector(selector.TextSelectorConfig())
+                        }
+                    )
+                else:
+                    SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                        {
+                            vol.Optional(
+                                CONF_VALUE,
+                            ): selector.TextSelector(selector.TextSelectorConfig())
+                        }
+                    )
+        else:
+            for el in sensor.SensorStateClass:
+                SENSOR_STATE_CLASS_SELECT_LIST.append(
+                    selector.SelectOptionDict(label=str(el.name), value=str(el.value))
+                )
+            value_type = "string"
+            if val_default:
+                SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                    {
+                        vol.Optional(
+                            CONF_VALUE,
+                            default=val_default_value,
+                        ): selector.TextSelector(selector.TextSelectorConfig())
+                    }
+                )
+            else:
+                SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                    {
+                        vol.Optional(
+                            CONF_VALUE,
+                        ): selector.TextSelector(selector.TextSelectorConfig())
+                    }
+                )
+
+        # _LOGGER.debug(
+        #    f"[Sensor Options Page 2] SENSOR_STATE_CLASS_SELECT_LIST: {SENSOR_STATE_CLASS_SELECT_LIST}"
+        # )
+        # _LOGGER.debug(
+        #    f"[Sensor Options Page 2] SENSOR_UNITS_SELECT_LIST: {SENSOR_UNITS_SELECT_LIST}"
+        # )
+
+        SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+            {
+                vol.Optional(
+                    CONF_ATTRIBUTES, default=self.config_entry.data.get(CONF_ATTRIBUTES)
+                ): selector.ObjectSelector(selector.ObjectSelectorConfig())
+            }
+        )
+        if len(SENSOR_STATE_CLASS_SELECT_LIST) > 1:
+            SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                {
+                    vol.Optional(
+                        sensor.CONF_STATE_CLASS,
+                        default=self.config_entry.data.get(
+                            sensor.CONF_STATE_CLASS, "None"
+                        )
+                        if (
+                            self.config_entry.data.get(CONF_DEVICE_CLASS)
+                            == self.sensor_options_page_1.get(CONF_DEVICE_CLASS)
+                        )
+                        else "None",
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=SENSOR_STATE_CLASS_SELECT_LIST,
+                            multiple=False,
+                            custom_value=False,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                }
+            )
+        else:
+            self.sensor_options_page_1[sensor.CONF_STATE_CLASS] = None
+
+        if len(SENSOR_UNITS_SELECT_LIST) > 1:
+            SENSOR_OPTIONS_PAGE_2_SCHEMA = SENSOR_OPTIONS_PAGE_2_SCHEMA.extend(
+                {
+                    vol.Optional(
+                        CONF_UNIT_OF_MEASUREMENT,
+                        default=self.config_entry.data.get(
+                            CONF_UNIT_OF_MEASUREMENT, "None"
+                        )
+                        if (
+                            self.config_entry.data.get(CONF_DEVICE_CLASS)
+                            == self.sensor_options_page_1.get(CONF_DEVICE_CLASS)
+                        )
+                        else "None",
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=SENSOR_UNITS_SELECT_LIST,
+                            multiple=False,
+                            custom_value=False,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                }
+            )
+        else:
+            self.sensor_options_page_1[CONF_UNIT_OF_MEASUREMENT] = None
+
+        _LOGGER.debug(f"[Sensor Options Page 2] value_type: {value_type}")
+        self.sensor_options_page_1.update({CONF_VALUE_TYPE: value_type})
+        return SENSOR_OPTIONS_PAGE_2_SCHEMA
 
     async def async_step_binary_sensor_options(
         self, user_input=None, errors=None
@@ -300,10 +819,12 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
             {
                 vol.Optional(
                     CONF_VALUE,
-                    default=self.config_entry.data.get(CONF_VALUE),
+                    default=self.config_entry.data.get(CONF_VALUE)
+                    if self.config_entry.data.get(CONF_VALUE) is not None
+                    else "None",
                 ): selector.SelectSelector(
                     selector.SelectSelectorConfig(
-                        options=["true", "false"],
+                        options=["None", "true", "false"],
                         translation_key="boolean_options",
                         multiple=False,
                         custom_value=False,
@@ -313,6 +834,17 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_ATTRIBUTES, default=self.config_entry.data.get(CONF_ATTRIBUTES)
                 ): selector.ObjectSelector(selector.ObjectSelectorConfig()),
+                vol.Optional(
+                    CONF_DEVICE_CLASS,
+                    default=self.config_entry.data.get(CONF_DEVICE_CLASS, "None"),
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=BINARY_SENSOR_DEVICE_CLASS_SELECT_LIST,
+                        multiple=False,
+                        custom_value=False,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
                 vol.Optional(
                     CONF_RESTORE,
                     default=self.config_entry.data.get(CONF_RESTORE, DEFAULT_RESTORE),
@@ -332,13 +864,19 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
             }
         )
 
+        if self.config_entry.data.get(CONF_NAME) is None or self.config_entry.data.get(
+            CONF_NAME
+        ) == self.config_entry.data.get(CONF_VARIABLE_ID):
+            disp_name = self.config_entry.data.get(CONF_VARIABLE_ID)
+        else:
+            disp_name = f"{self.config_entry.data.get(CONF_NAME)} ({self.config_entry.data.get(CONF_VARIABLE_ID)})"
+
         return self.async_show_form(
             step_id="binary_sensor_options",
             data_schema=BINARY_SENSOR_OPTIONS_SCHEMA,
+            errors=errors,
             description_placeholders={
                 "component_config_url": COMPONENT_CONFIG_URL,
-                "entity_name": self.config_entry.data.get(
-                    CONF_NAME, self.config_entry.data.get(CONF_VARIABLE_ID)
-                ),
+                "disp_name": disp_name,
             },
         )

--- a/custom_components/variable/const.py
+++ b/custom_components/variable/const.py
@@ -1,5 +1,6 @@
 from homeassistant.const import Platform
 
+PLAFORM_NAME = "Variables+History"
 DOMAIN = "variable"
 
 PLATFORMS: list[str] = [Platform.SENSOR, Platform.BINARY_SENSOR]
@@ -16,6 +17,7 @@ CONF_ENTITY_PLATFORM = "entity_platform"
 CONF_FORCE_UPDATE = "force_update"
 CONF_RESTORE = "restore"
 CONF_VALUE = "value"
+CONF_VALUE_TYPE = "value_type"
 CONF_VARIABLE_ID = "variable_id"
 CONF_YAML_VARIABLE = "yaml_variable"
 CONF_EXCLUDE_FROM_RECORDER = "exclude_from_recorder"

--- a/custom_components/variable/helpers.py
+++ b/custom_components/variable/helpers.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import datetime
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def to_num(s):
+    try:
+        return int(s)
+    except ValueError:
+        try:
+            return float(s)
+        except ValueError:
+            return None
+
+
+def value_to_type(init_str, value_type):
+
+    if init_str is None or (
+        isinstance(init_str, str)
+        and init_str.lower() in ["", "none", "unknown", "unavailable"]
+    ):
+        _LOGGER.debug(f"[value_to_type] value: {init_str}, returning None")
+        return None
+
+    elif value_type == "date":
+        try:
+            value_date = datetime.date.fromisoformat(init_str)
+        except ValueError:
+            raise ValueError(f"Cannot convert string to {value_type}: {init_str}")
+            return None
+        else:
+            _LOGGER.debug(f"[value_to_type] date value: |{value_date}|")
+            return value_date
+
+    elif value_type == "datetime":
+        try:
+            value_datetime = datetime.datetime.fromisoformat(init_str)
+        except ValueError:
+            raise ValueError(f"Cannot convert string to {value_type}: {init_str}")
+            return None
+        else:
+            _LOGGER.debug(f"[value_to_type] datetime value: |{value_datetime}|")
+            return value_datetime
+
+    elif value_type == "number":
+        if (value_num := to_num(init_str)) is not None:
+            _LOGGER.debug(f"[value_to_type] number value: |{value_num}|")
+            return value_num
+        else:
+            raise ValueError(f"Cannot convert string to {value_type}: {init_str}")
+    elif value_type == "string":
+        _LOGGER.debug(f"[value_to_type] stringvalue: |{init_str}|")
+        return init_str
+    else:
+        raise ValueError(f"Invalid value_type: {value_type}")
+        return None

--- a/custom_components/variable/helpers.py
+++ b/custom_components/variable/helpers.py
@@ -16,44 +16,167 @@ def to_num(s):
             return None
 
 
-def value_to_type(init_str, value_type):
+def value_to_type(init_val, dest_type):  # noqa: C901
 
-    if init_str is None or (
-        isinstance(init_str, str)
-        and init_str.lower() in ["", "none", "unknown", "unavailable"]
+    if init_val is None or (
+        isinstance(init_val, str)
+        and init_val.lower() in ["", "none", "unknown", "unavailable"]
     ):
-        _LOGGER.debug(f"[value_to_type] value: {init_str}, returning None")
+        _LOGGER.debug(f"[value_to_type] value: {init_val}, returning None")
         return None
 
-    elif value_type == "date":
-        try:
-            value_date = datetime.date.fromisoformat(init_str)
-        except ValueError:
-            raise ValueError(f"Cannot convert string to {value_type}: {init_str}")
-            return None
-        else:
-            _LOGGER.debug(f"[value_to_type] date value: |{value_date}|")
-            return value_date
+    _LOGGER.debug(
+        f"[value_to_type] initial value: {init_val}, initial type: {type(init_val)}, dest type: {dest_type}"
+    )
+    if isinstance(init_val, str):
+        if dest_type is None or dest_type == "string":
+            _LOGGER.debug(
+                f"[value_to_type] return value: {init_val}, type: {type(init_val)}"
+            )
+            return init_val
 
-    elif value_type == "datetime":
-        try:
-            value_datetime = datetime.datetime.fromisoformat(init_str)
-        except ValueError:
-            raise ValueError(f"Cannot convert string to {value_type}: {init_str}")
-            return None
-        else:
-            _LOGGER.debug(f"[value_to_type] datetime value: |{value_datetime}|")
-            return value_datetime
+        elif dest_type == "date":
+            try:
+                value_date = datetime.date.fromisoformat(init_val)
+            except ValueError:
+                _LOGGER.debug(
+                    f"Cannot convert string to {dest_type}: {init_val}, returning None"
+                )
+                raise ValueError(f"Cannot convert string to {dest_type}: {init_val}")
+                return None
+            else:
+                _LOGGER.debug(
+                    f"[value_to_type] return value: {value_date}, type: {type(value_date)}"
+                )
+                return value_date
 
-    elif value_type == "number":
-        if (value_num := to_num(init_str)) is not None:
-            _LOGGER.debug(f"[value_to_type] number value: |{value_num}|")
-            return value_num
+        elif dest_type == "datetime":
+            try:
+                value_datetime = datetime.datetime.fromisoformat(init_val)
+            except ValueError:
+                _LOGGER.debug(
+                    f"Cannot convert string to {dest_type}: {init_val}, returning None"
+                )
+                raise ValueError(f"Cannot convert string to {dest_type}: {init_val}")
+                return None
+            else:
+                _LOGGER.debug(
+                    f"[value_to_type] return value: {value_datetime}, type: {type(value_datetime)}"
+                )
+                return value_datetime
+
+        elif dest_type == "number":
+            if (value_num := to_num(init_val)) is not None:
+                _LOGGER.debug(
+                    f"[value_to_type] return value: {value_num}, type: {type(value_num)}"
+                )
+                return value_num
+            else:
+                _LOGGER.debug(
+                    f"Cannot convert string to {dest_type}: {init_val}, returning None"
+                )
+                raise ValueError(f"Cannot convert string to {dest_type}: {init_val}")
         else:
-            raise ValueError(f"Cannot convert string to {value_type}: {init_str}")
-    elif value_type == "string":
-        _LOGGER.debug(f"[value_to_type] stringvalue: |{init_str}|")
-        return init_str
+            _LOGGER.debug(f"Invalid dest_type: {dest_type}, returning None")
+            raise ValueError(f"Invalid dest_type: {dest_type}")
+            return None
+    elif isinstance(init_val, int) or isinstance(init_val, float):
+        if dest_type is None or dest_type == "string":
+            _LOGGER.debug(
+                f"[value_to_type] return value: {str(init_val)}, type: {type(str(init_val))}"
+            )
+            return str(init_val)
+        elif dest_type == "date":
+            try:
+                value_date = datetime.date.fromisoformat(str(init_val))
+            except ValueError:
+                _LOGGER.debug(
+                    f"Cannot convert number to {dest_type}: {init_val}, returning None"
+                )
+                raise ValueError(f"Cannot convert number to {dest_type}: {init_val}")
+                return None
+            else:
+                _LOGGER.debug(
+                    f"[value_to_type] return value: {value_date}, type: {type(value_date)}"
+                )
+                return value_date
+
+        elif dest_type == "datetime":
+            try:
+                value_datetime = datetime.datetime.fromisoformat(str(init_val))
+            except ValueError:
+                _LOGGER.debug(
+                    f"Cannot convert number to {dest_type}: {init_val}, returning None"
+                )
+                raise ValueError(f"Cannot convert number to {dest_type}: {init_val}")
+                return None
+            else:
+                _LOGGER.debug(
+                    f"[value_to_type] return value: {value_datetime}, type: {type(value_datetime)}"
+                )
+                return value_datetime
+        elif dest_type == "number":
+            _LOGGER.debug(
+                f"[value_to_type] return value: {init_val}, type: {type(init_val)}"
+            )
+            return init_val
+        else:
+            _LOGGER.debug(f"Invalid dest_type: {dest_type}, returning None")
+            raise ValueError(f"Invalid dest_type: {dest_type}")
+            return None
+    elif isinstance(init_val, datetime.date):
+        if dest_type is None or dest_type == "string":
+            _LOGGER.debug(
+                f"[value_to_type] return value: {init_val.isoformat()}, type: {type(init_val.isoformat())}"
+            )
+            return init_val.isoformat()
+        elif dest_type == "date":
+            _LOGGER.debug(
+                f"[value_to_type] return value: {init_val}, type: {type(init_val)}"
+            )
+            return init_val
+        elif dest_type == "datetime":
+            _LOGGER.debug(
+                f"[value_to_type] return value: {datetime.datetime.combine(init_val, datetime.time.min)}, "
+                + f"type: {type(datetime.datetime.combine(init_val, datetime.time.min))}"
+            )
+            return datetime.datetime.combine(init_val, datetime.time.min)
+        elif dest_type == "number":
+            _LOGGER.debug(
+                f"[value_to_type] return value: {datetime.datetime.combine(init_val, datetime.time.min).timestamp()}, "
+                + f"type: {type(datetime.datetime.combine(init_val, datetime.time.min).timestamp())}"
+            )
+            return datetime.datetime.combine(init_val, datetime.time.min).timestamp()
+        else:
+            _LOGGER.debug(f"Invalid dest_type: {dest_type}, returning None")
+            raise ValueError(f"Invalid dest_type: {dest_type}")
+            return None
+    elif isinstance(init_val, datetime.datetime):
+        if dest_type is None or dest_type == "string":
+            _LOGGER.debug(
+                f"[value_to_type] return value: {init_val.isoformat()}, type: {type(init_val.isoformat())}"
+            )
+            return init_val.isoformat()
+        elif dest_type == "date":
+            _LOGGER.debug(
+                f"[value_to_type] return value: {init_val.date()}, type: {type(init_val.date())}"
+            )
+            return init_val.date()
+        elif dest_type == "datetime":
+            _LOGGER.debug(
+                f"[value_to_type] return value: {init_val}, type: {type(init_val)}"
+            )
+            return init_val
+        elif dest_type == "number":
+            _LOGGER.debug(
+                f"[value_to_type] return value: {init_val.timestamp()}, type: {type(init_val.timestamp())}"
+            )
+            return init_val.timestamp()
+        else:
+            _LOGGER.debug(f"Invalid dest_type: {dest_type}, returning None")
+            raise ValueError(f"Invalid dest_type: {dest_type}")
+            return None
     else:
-        raise ValueError(f"Invalid value_type: {value_type}")
+        _LOGGER.debug(f"Invalid initial type: {type(init_val)}, returning None")
+        raise ValueError(f"Invalid initial type: {type(init_val)}")
         return None

--- a/custom_components/variable/manifest.json
+++ b/custom_components/variable/manifest.json
@@ -12,6 +12,6 @@
     "documentation": "https://github.com/Wibias/hass-variables",
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/Wibias/hass-variables/issues",
-    "requirements": [],
+    "requirements": ["iso4217==1.11.20220401"],
     "version": "3.2.3"
 }

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -3,13 +3,19 @@ import copy
 import logging
 
 from homeassistant.components.recorder import DATA_INSTANCE as RECORDER_INSTANCE
-from homeassistant.components.sensor import PLATFORM_SCHEMA, RestoreSensor
+from homeassistant.components.sensor import (
+    CONF_STATE_CLASS,
+    PLATFORM_SCHEMA,
+    RestoreSensor,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     ATTR_ICON,
+    CONF_DEVICE_CLASS,
     CONF_ICON,
     CONF_NAME,
+    CONF_UNIT_OF_MEASUREMENT,
     Platform,
 )
 from homeassistant.core import HomeAssistant
@@ -27,6 +33,7 @@ from .const import (
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
     CONF_VALUE,
+    CONF_VALUE_TYPE,
     CONF_VARIABLE_ID,
     CONF_YAML_VARIABLE,
     DEFAULT_EXCLUDE_FROM_RECORDER,
@@ -36,6 +43,7 @@ from .const import (
     DEFAULT_RESTORE,
     DOMAIN,
 )
+from .helpers import value_to_type
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,7 +130,12 @@ class Variable(RestoreSensor):
             self._attr_name = config.get(CONF_VARIABLE_ID)
         self._attr_icon = config.get(CONF_ICON)
         if config.get(CONF_VALUE) is not None:
-            self._attr_native_value = config.get(CONF_VALUE)
+            if isinstance(config.get(CONF_VALUE), str) and config.get(
+                CONF_VALUE
+            ).lower() in ["", "none", "unknown", "unavailable"]:
+                self._attr_native_value = None
+            else:
+                self._attr_native_value = config.get(CONF_VALUE)
         self._restore = config.get(CONF_RESTORE)
         self._force_update = config.get(CONF_FORCE_UPDATE)
         self._yaml_variable = config.get(CONF_YAML_VARIABLE)
@@ -137,6 +150,10 @@ class Variable(RestoreSensor):
             )
         else:
             self._attr_extra_state_attributes = None
+        self._value_type = config.get(CONF_VALUE_TYPE)
+        self._attr_device_class = config.get(CONF_DEVICE_CLASS)
+        self._attr_native_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
+        self._attr_state_class = config.get(CONF_STATE_CLASS)
         self.entity_id = generate_entity_id(
             ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
         )
@@ -169,7 +186,21 @@ class Variable(RestoreSensor):
                 _LOGGER.debug(
                     f"({self._attr_name}) Restored sensor: {sensor.as_dict()}"
                 )
-                self._attr_native_value = sensor.native_value
+
+                if isinstance(
+                    sensor.native_value, str
+                ) and sensor.native_value.lower() in [
+                    "",
+                    "none",
+                    "unknown",
+                    "unavailable",
+                ]:
+                    self._attr_native_value = None
+                else:
+                    self._attr_native_value = sensor.native_value
+                # self._attr_native_unit_of_measurement = (
+                #    sensor.native_unit_of_measurement
+                # )
             state = await self.async_get_last_state()
             if state:
                 _LOGGER.debug(f"({self._attr_name}) Restored state: {state.as_dict()}")
@@ -193,21 +224,47 @@ class Variable(RestoreSensor):
                     and hasattr(sensor, "native_value")
                     and sensor.native_value != state.state
                 ):
-                    _LOGGER.info(
-                        f"({self._attr_name}) Restored values are different. "
-                        f"native_value: {sensor.native_value} | state: {state.state}"
-                    )
-                    self._attr_native_value = state.state
+                    if isinstance(state.state, str) and state.state.lower() in [
+                        "",
+                        "none",
+                        "unknown",
+                        "unavailable",
+                    ]:
+                        newval = None
+                    else:
+                        try:
+                            newval = value_to_type(state.state, self._value_type)
+                        except ValueError:
+                            newval = state.state
+
+                    _LOGGER.debug(f"({self._attr_name}) Updated state: |{newval}|")
+                    if sensor.native_value is None or sensor.native_value in [
+                        "unknown",
+                        "unavailable",
+                    ]:
+                        nat_val = None
+                    else:
+                        nat_val = sensor.native_value
+                    if nat_val != newval:
+                        _LOGGER.info(
+                            f"({self._attr_name}) Restored values are different. "
+                            f"native_value: {nat_val} | state: {newval}"
+                        )
+                        self._attr_native_value = newval
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
         if RECORDER_INSTANCE in self._hass.data:
             ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
             if self.entity_id:
-                _LOGGER.debug(
-                    f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
-                )
-                ha_history_recorder.entity_filter._exclude_e.discard(self.entity_id)
+                try:
+                    ha_history_recorder.entity_filter._exclude_e.discard(self.entity_id)
+                except AttributeError:
+                    pass
+                else:
+                    _LOGGER.debug(
+                        f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
+                    )
 
     @property
     def should_poll(self):
@@ -238,16 +295,13 @@ class Variable(RestoreSensor):
         else:
             return None
 
-    async def async_update_variable(
-        self,
-        value=None,
-        attributes=None,
-        replace_attributes=False,
-    ) -> None:
+    # async def async_update_variable(self, value, attributes, replace_attributes=False) -> None:
+    async def async_update_variable(self, **kwargs) -> None:
         """Update Sensor Variable."""
 
         updated_attributes = None
 
+        replace_attributes = kwargs.get(ATTR_REPLACE_ATTRIBUTES, False)
         _LOGGER.debug(
             f"({self._attr_name}) [async_update_variable] Replace Attributes: {replace_attributes}"
         )
@@ -259,6 +313,7 @@ class Variable(RestoreSensor):
         ):
             updated_attributes = copy.deepcopy(self._attr_extra_state_attributes)
 
+        attributes = kwargs.get(ATTR_ATTRIBUTES)
         if attributes is not None:
             if isinstance(attributes, MutableMapping):
                 _LOGGER.debug(
@@ -274,6 +329,19 @@ class Variable(RestoreSensor):
                     f"({self._attr_name}) AttributeError: Attributes must be a dictionary: {attributes}"
                 )
 
+        if ATTR_VALUE in kwargs:
+            try:
+                newval = value_to_type(kwargs.get(ATTR_VALUE), self._value_type)
+            except ValueError:
+                ERROR = f"The value entered is not compatible with the selected device_class: {self._attr_device_class}. Expected: {self._value_type}. Value: {kwargs.get(ATTR_VALUE)}"
+                raise ValueError(ERROR)
+                return
+            else:
+                _LOGGER.debug(
+                    f"({self._attr_name}) [async_update_variable] New Value: {newval}"
+                )
+                self._attr_native_value = newval
+
         if updated_attributes is not None:
             self._attr_extra_state_attributes = copy.deepcopy(updated_attributes)
             _LOGGER.debug(
@@ -282,12 +350,4 @@ class Variable(RestoreSensor):
         else:
             self._attr_extra_state_attributes = None
 
-        if value is not None:
-            _LOGGER.debug(
-                f"({self._attr_name}) [async_update_variable] New Value: {value}"
-            )
-            self._attr_native_value = value
-
         self.async_write_ha_state()
-        _LOGGER.debug(f"({self._attr_name}) [async_update_variable] self: {self}")
-        _LOGGER.debug(f"({self._attr_name}) [async_update_variable] name: {self.name}")

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -129,13 +129,13 @@ class Variable(RestoreSensor):
         else:
             self._attr_name = config.get(CONF_VARIABLE_ID)
         self._attr_icon = config.get(CONF_ICON)
-        if config.get(CONF_VALUE) is not None:
-            if isinstance(config.get(CONF_VALUE), str) and config.get(
-                CONF_VALUE
-            ).lower() in ["", "none", "unknown", "unavailable"]:
-                self._attr_native_value = None
-            else:
-                self._attr_native_value = config.get(CONF_VALUE)
+        if config.get(CONF_VALUE) is None or (
+            isinstance(config.get(CONF_VALUE), str)
+            and config.get(CONF_VALUE).lower() in ["", "none", "unknown", "unavailable"]
+        ):
+            self._attr_native_value = None
+        else:
+            self._attr_native_value = config.get(CONF_VALUE)
         self._restore = config.get(CONF_RESTORE)
         self._force_update = config.get(CONF_FORCE_UPDATE)
         self._yaml_variable = config.get(CONF_YAML_VARIABLE)
@@ -187,14 +187,16 @@ class Variable(RestoreSensor):
                     f"({self._attr_name}) Restored sensor: {sensor.as_dict()}"
                 )
 
-                if isinstance(
-                    sensor.native_value, str
-                ) and sensor.native_value.lower() in [
-                    "",
-                    "none",
-                    "unknown",
-                    "unavailable",
-                ]:
+                if sensor.native_value is None or (
+                    isinstance(sensor.native_value, str)
+                    and sensor.native_value.lower()
+                    in [
+                        "",
+                        "none",
+                        "unknown",
+                        "unavailable",
+                    ]
+                ):
                     self._attr_native_value = None
                 else:
                     self._attr_native_value = sensor.native_value
@@ -224,12 +226,16 @@ class Variable(RestoreSensor):
                     and hasattr(sensor, "native_value")
                     and sensor.native_value != state.state
                 ):
-                    if isinstance(state.state, str) and state.state.lower() in [
-                        "",
-                        "none",
-                        "unknown",
-                        "unavailable",
-                    ]:
+                    if state.state is None or (
+                        isinstance(state.state, str)
+                        and state.state.lower()
+                        in [
+                            "",
+                            "none",
+                            "unknown",
+                            "unavailable",
+                        ]
+                    ):
                         newval = None
                     else:
                         try:
@@ -238,10 +244,16 @@ class Variable(RestoreSensor):
                             newval = state.state
 
                     _LOGGER.debug(f"({self._attr_name}) Updated state: |{newval}|")
-                    if sensor.native_value is None or sensor.native_value in [
-                        "unknown",
-                        "unavailable",
-                    ]:
+                    if sensor.native_value is None or (
+                        isinstance(sensor.native_value, str)
+                        and sensor.native_value.lower()
+                        in [
+                            "",
+                            "none",
+                            "unknown",
+                            "unavailable",
+                        ]
+                    ):
                         nat_val = None
                     else:
                         nat_val = sensor.native_value

--- a/custom_components/variable/services.yaml
+++ b/custom_components/variable/services.yaml
@@ -45,6 +45,7 @@ update_binary_sensor:
           mode: list
           translation_key: "boolean_options"
           options:
+            - "None"
             - "true"
             - "false"
     attributes:

--- a/custom_components/variable/strings.json
+++ b/custom_components/variable/strings.json
@@ -13,13 +13,22 @@
           "name": "[%key:common::config_flow::data::name%]",
           "variable_id": "Variable ID",
           "icon": "Icon",
-          "value": "Initial Value",
-          "attributes": "Initial Attributes",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Sensor Variable"
+      },
+      "sensor_page_2": {
+        "title": "Variables+History - Sensor Page 2",
+        "data": {
+          "value": "Initial Value",
+          "attributes": "Initial Attributes",
+          "state_class": "State Class",
+          "unit_of_measurement": "Unit of Measurement"
+        },
+        "description": "Create a new Sensor Variable Page 2"
       },
       "add_binary_sensor": {
         "title": "Variables+History - Binary Sensor",
@@ -29,12 +38,17 @@
           "icon": "Icon",
           "value": "Initial Value",
           "attributes": "Initial Attributes",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Binary Sensor Variable"
       }
+    },
+    "error": {
+      "invalid_value_type": "The value entered is not compatible with the selected device_class",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   },
   "options": {
@@ -43,11 +57,20 @@
       "sensor_options": {
         "title": "Variables+History - Sensor",
         "data": {
-          "value": "Value (typically only useful if Restore on Restart is False)",
-          "attributes": "Attributes (typically only useful if Restore on Restart is False)",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
+        },
+        "description": "Update existing Variable Sensor"
+      },
+      "sensor_options_page_2": {
+        "title": "Variables+History - Sensor Page 2",
+        "data": {
+          "value": "Value (typically only useful if Restore on Restart is False)",
+          "attributes": "Attributes (typically only useful if Restore on Restart is False)",
+          "state_class": "State Class",
+          "unit_of_measurement": "Unit of Measurement"
         },
         "description": "Update existing Variable Sensor"
       },
@@ -56,6 +79,7 @@
         "data": {
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
@@ -66,6 +90,10 @@
     "abort": {
       "yaml_variable": "Cannot change options here for Variables created by YAML.\n\nTo use the User Interface to manage this Variable, you will need to:\n1. Remove it from YAML\n2. Delete the imported Variable entity from Home Assistant\n3. Restart Home Assistant\n4. Manually recreate it in Home Assistant, Integrations, +Add Integration.",
       "yaml_update_error": "Unable to update YAML Sensor Variable"
+    },
+    "error": {
+      "invalid_value_type": "The value entered is not compatible with the selected device_class",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   },
   "selector": {

--- a/custom_components/variable/translations/en.json
+++ b/custom_components/variable/translations/en.json
@@ -13,13 +13,22 @@
           "name": "Variable Name",
           "variable_id": "Variable ID",
           "icon": "Icon",
-          "value": "Initial Value",
-          "attributes": "Initial Attributes",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Sensor Variable\nSee [Configuration Options]({component_config_url}) on GitHub for details"
+      },
+      "sensor_page_2": {
+        "title": "Variables+History - Sensor Page 2",
+        "data": {
+          "value": "Initial Value",
+          "attributes": "Initial Attributes",
+          "state_class": "State Class",
+          "unit_of_measurement": "Unit of Measurement"
+        },
+        "description": "Create a new Sensor Variable Page 2\n\n**Variable:&nbsp;{disp_name}**\n**Device Class:&nbsp;{device_class}**\n**Value Type:&nbsp;{value_type}**"
       },
       "add_binary_sensor": {
         "title": "Variables+History - Binary Sensor",
@@ -29,12 +38,17 @@
           "icon": "Icon",
           "value": "Initial Value",
           "attributes": "Initial Attributes",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
         },
         "description": "Create a new Binary Sensor Variable\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       }
+    },
+    "error": {
+      "invalid_value_type": "The value entered is not compatible with the selected device_class: {device_class}. Expected {value_type}.",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   },
   "options": {
@@ -43,29 +57,43 @@
       "sensor_options": {
         "title": "Variables+History - Sensor",
         "data": {
-          "value": "Value (typically only useful if Restore on Restart is False)",
-          "attributes": "Attributes (typically only useful if Restore on Restart is False)",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
         },
-        "description": "**Updating Sensor:&nbsp;{entity_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
+        "description": "**Updating Sensor:&nbsp;{disp_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
+      },
+      "sensor_options_page_2": {
+        "title": "Variables+History - Sensor Page 2",
+        "data": {
+          "value": "Value (typically only useful if Restore on Restart is False)",
+          "attributes": "Attributes (typically only useful if Restore on Restart is False)",
+          "state_class": "State Class",
+          "unit_of_measurement": "Unit of Measurement"
+        },
+        "description": "Updating Sensor Variable Page 2\n\n**Variable:&nbsp;{disp_name}**\n**Device Class:&nbsp;{device_class}**\n**Value Type:&nbsp;{value_type}**"
       },
       "binary_sensor_options": {
         "title": "Variables+History - Binary Sensor",
         "data": {
           "value": "Value (typically only useful if Restore on Restart is False)",
           "attributes": "Attributes (typically only useful if Restore on Restart is False)",
+          "device_class": "Device Class",
           "restore": "Restore on Restart",
           "force_update": "Force Update",
           "exclude_from_recorder": "Exclude from Recorder"
         },
-        "description": "**Updating Binary Sensor:&nbsp;{entity_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
+        "description": "**Updating Binary Sensor:&nbsp;{disp_name}**\nSee [Configuration Options]({component_config_url}) on GitHub for details"
       }
     },
     "abort": {
       "yaml_variable": "Cannot change options here for Variables created by YAML.\n\nTo use the User Interface to manage this Variable, you will need to:\n1. Remove it from YAML\n2. Delete the imported Variable entity from Home Assistant\n3. Restart Home Assistant\n4. Manually recreate it in Home Assistant, Integrations, +Add Integration.",
       "yaml_update_error": "Unable to update YAML Sensor Variable"
+    },
+    "error": {
+      "invalid_value_type": "The value entered is not compatible with the selected device_class: {device_class}. Expected {value_type}.",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   },
   "selector": {


### PR DESCRIPTION
* Add Device Class, State Class, and Unit of Measurement for Sensors (Fixes #57)
* Add Device Class for Binary Sensors
* Add None as an option for Binary Sensors
* Fixed some other inconsistency errors

**Notes:** 
1.  If a Device Class for a Sensor is set, the Value must be of the type that is required by the Device Class (ex. for a Device Class of Duration the Value must be a Number). This is enforced both when creating the Sensor Variable and when updating the Value of the Sensor Variable with the `variable.update_sensor` service.
2.  If a Device Class for a Sensor is set and a Unit of Measurement is not set, Home Assistant will give a Warning.
3.  If the Device Class of a Sensor is changed and the new Device Class requires a different type of Value, the old Value will be cleared.