### PR TITLE
Restore Exclude from Recorder functionality

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "custom_components/variable/recorder_history_prefilter"]
+	path = custom_components/variable/recorder_history_prefilter
+	url = https://github.com/gcobb321/recorder_history_prefilter

--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform, selector
 from homeassistant.helpers.entity import generate_entity_id
+from homeassistant.helpers.entity_registry import async_get
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import slugify
 import voluptuous as vol
@@ -161,9 +162,18 @@ class Variable(BinarySensorEntity, RestoreEntity):
             )
         else:
             self._attr_extra_state_attributes = None
-        self.entity_id = generate_entity_id(
-            ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
+
+        registry = async_get(self._hass)
+        current_entity_id = registry.async_get_entity_id(
+            PLATFORM, DOMAIN, self._attr_unique_id
         )
+        if current_entity_id is not None:
+            self.entity_id = current_entity_id
+        else:
+            self.entity_id = generate_entity_id(
+                ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
+            )
+        _LOGGER.debug(f"({self._attr_name}) entity_id: {self.entity_id}")
         if self._exclude_from_recorder:
             self.disable_recorder()
 

--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -40,6 +40,7 @@ from .const import (
     DEFAULT_RESTORE,
     DOMAIN,
 )
+from .recorder_history_prefilter import recorder_prefilter
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -168,17 +169,8 @@ class Variable(BinarySensorEntity, RestoreEntity):
 
     def disable_recorder(self):
         if RECORDER_INSTANCE in self._hass.data:
-            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
             _LOGGER.info(f"({self._attr_name}) [disable_recorder] Disabling Recorder")
-            if self.entity_id:
-                try:
-                    ha_history_recorder.entity_filter._exclude_e.add(self.entity_id)
-                except AttributeError:
-                    pass
-                else:
-                    _LOGGER.debug(
-                        f"({self._attr_name}) [disable_recorder] _exclude_e: {ha_history_recorder.entity_filter._exclude_e}"
-                    )
+            recorder_prefilter.add_filter(self._hass, self.entity_id)
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""
@@ -215,16 +207,10 @@ class Variable(BinarySensorEntity, RestoreEntity):
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
         if RECORDER_INSTANCE in self._hass.data:
-            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
-            if self.entity_id:
-                try:
-                    ha_history_recorder.entity_filter._exclude_e.discard(self.entity_id)
-                except AttributeError:
-                    pass
-                else:
-                    _LOGGER.debug(
-                        f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
-                    )
+            _LOGGER.debug(
+                f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
+            )
+            recorder_prefilter.remove_filter(self._hass, self.entity_id)
 
     @property
     def should_poll(self):

--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -18,7 +18,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform, selector
 from homeassistant.helpers.entity import generate_entity_id
-from homeassistant.helpers.entity_registry import async_get
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import slugify
 import voluptuous as vol
@@ -162,18 +161,9 @@ class Variable(BinarySensorEntity, RestoreEntity):
             )
         else:
             self._attr_extra_state_attributes = None
-
-        registry = async_get(self._hass)
-        current_entity_id = registry.async_get_entity_id(
-            PLATFORM, DOMAIN, self._attr_unique_id
+        self.entity_id = generate_entity_id(
+            ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
         )
-        if current_entity_id is not None:
-            self.entity_id = current_entity_id
-        else:
-            self.entity_id = generate_entity_id(
-                ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
-            )
-        _LOGGER.debug(f"({self._attr_name}) entity_id: {self.entity_id}")
         if self._exclude_from_recorder:
             self.disable_recorder()
 

--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -216,7 +216,7 @@ class Variable(BinarySensorEntity, RestoreEntity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
-        if RECORDER_INSTANCE in self._hass.data:
+        if RECORDER_INSTANCE in self._hass.data and self._exclude_from_recorder:
             _LOGGER.debug(
                 f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
             )

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -21,7 +21,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import generate_entity_id
-import homeassistant.helpers.entity_registry as er
 from homeassistant.util import slugify
 import voluptuous as vol
 
@@ -161,19 +160,9 @@ class Variable(RestoreSensor):
                 )
             except ValueError:
                 self._attr_native_value = None
-
-        registry = er.async_get(self._hass)
-        current_entity_id = registry.async_get_entity_id(
-            PLATFORM, DOMAIN, self._attr_unique_id
+        self.entity_id = generate_entity_id(
+            ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
         )
-        if current_entity_id is not None:
-            self.entity_id = current_entity_id
-        else:
-            self.entity_id = generate_entity_id(
-                ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
-            )
-        _LOGGER.debug(f"({self._attr_name}) entity_id: {self.entity_id}")
-
         if self._exclude_from_recorder:
             self.disable_recorder()
 

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -281,7 +281,7 @@ class Variable(RestoreSensor):
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
-        if RECORDER_INSTANCE in self._hass.data:
+        if RECORDER_INSTANCE in self._hass.data and self._exclude_from_recorder:
             _LOGGER.debug(
                 f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
             )

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import generate_entity_id
+import homeassistant.helpers.entity_registry as er
 from homeassistant.util import slugify
 import voluptuous as vol
 
@@ -160,9 +161,19 @@ class Variable(RestoreSensor):
                 )
             except ValueError:
                 self._attr_native_value = None
-        self.entity_id = generate_entity_id(
-            ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
+
+        registry = er.async_get(self._hass)
+        current_entity_id = registry.async_get_entity_id(
+            PLATFORM, DOMAIN, self._attr_unique_id
         )
+        if current_entity_id is not None:
+            self.entity_id = current_entity_id
+        else:
+            self.entity_id = generate_entity_id(
+                ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
+            )
+        _LOGGER.debug(f"({self._attr_name}) entity_id: {self.entity_id}")
+
         if self._exclude_from_recorder:
             self.disable_recorder()
 


### PR DESCRIPTION
Restore the option to exclude the variable from the recorder. Previous method stopped working in HA 2023.6.
Thanks @gcobb321 for the [recorder_history_prefilter repo](https://github.com/gcobb321/recorder_history_prefilter)
Fixes #62 