### PR TITLE
Fix issues with Sensor Variable changing state on restart

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "custom_components/variable/recorder_history_prefilter"]
+	path = custom_components/variable/recorder_history_prefilter
+	url = https://github.com/gcobb321/recorder_history_prefilter

--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -3,9 +3,17 @@ import json
 import logging
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_FRIENDLY_NAME, CONF_ICON, CONF_NAME, Platform
+from homeassistant.const import (
+    CONF_ENTITY_ID,
+    CONF_FRIENDLY_NAME,
+    CONF_ICON,
+    CONF_NAME,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers import config_validation as cv
+
+# from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType
 import voluptuous as vol
 
@@ -30,6 +38,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_SET_VARIABLE_LEGACY = "set_variable"
 SERVICE_SET_ENTITY_LEGACY = "set_entity"
+SERVICE_UPDATE_SENSOR = "update_sensor"
 
 SERVICE_SET_VARIABLE_LEGACY_SCHEMA = vol.Schema(
     {
@@ -60,93 +69,44 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
     async def async_set_variable_legacy_service(call):
         """Handle calls to the set_variable legacy service."""
 
+        _LOGGER.debug(f"[async_set_variable_legacy_service] Pre call:  {call}")
+        _LOGGER.debug(f"[async_set_variable_legacy_service] Pre call data: {call.data}")
         ENTITY_ID_FORMAT = Platform.SENSOR + ".{}"
-
-        # _LOGGER.debug("[async_set_variable_legacy_service] call: " + str(call))
-
         entity_id = ENTITY_ID_FORMAT.format(call.data.get(ATTR_VARIABLE))
-        # _LOGGER.debug("[async_set_variable_legacy_service] entity_id: " + str(entity_id))
-        entity_registry = er.async_get(hass)
-        entity = entity_registry.async_get(entity_id)
-
-        # _LOGGER.debug("[async_set_variable_legacy_service] entity: " + str(entity))
-        if entity and entity.platform == DOMAIN:
-            _LOGGER.debug("[async_set_variable_legacy_service] Updating variable")
-            pre_state = hass.states.get(entity_id=entity_id)
-            pre_attr = hass.states.get(entity_id=entity_id).attributes
-            _LOGGER.debug(
-                f"[async_set_variable_legacy_service] Previous state: {pre_state.as_dict()}"
-            )
-            _LOGGER.debug(
-                f"[async_set_variable_legacy_service] Previous attr: {pre_attr}"
-            )
-            if not call.data.get(ATTR_REPLACE_ATTRIBUTES, False):
-                if call.data.get(ATTR_ATTRIBUTES):
-                    new_attr = pre_attr | call.data.get(ATTR_ATTRIBUTES)
-                else:
-                    new_attr = pre_attr
-            else:
-                new_attr = call.data.get(ATTR_ATTRIBUTES)
-            _LOGGER.debug(
-                f"[async_set_variable_legacy_service] Updated attr: {new_attr}"
-            )
-            hass.states.async_set(
-                entity_id=entity_id,
-                new_state=call.data.get(ATTR_VALUE),
-                attributes=new_attr,
-            )
-            _LOGGER.debug(
-                f"[async_set_variable_legacy_service] Post state: "
-                f"{hass.states.get(entity_id=entity_id).as_dict()}"
-            )
-        else:
-            _LOGGER.warning(
-                f"variable.set_variable Service Failed. Unknown Variable: {entity_id}"
-            )
+        call.data.update({ATTR_ENTITY: entity_id})
+        _LOGGER.debug(f"[async_set_variable_legacy_service] Post call:  {call}")
+        _LOGGER.debug(
+            f"[async_set_variable_legacy_service] Post call data: {call.data}"
+        )
+        await _async_set_legacy_service(call)
 
     async def async_set_entity_legacy_service(call):
         """Handle calls to the set_entity legacy service."""
 
-        # _LOGGER.debug(f"[async_set_entity_legacy_service] call: {call}")
+        _LOGGER.debug(f"[async_set_entity_legacy_service] call: {call}")
+        _LOGGER.debug(f"[async_set_entity_legacy_service] call data: {call.data}")
+        await _async_set_legacy_service(call)
 
-        entity_id: str = call.data.get(ATTR_ENTITY)
-        # _LOGGER.debug(f"[async_set_entity_legacy_service] entity_id: {entity_id}")
-        entity_registry = er.async_get(hass)
-        entity = entity_registry.async_get(entity_id)
+    async def _async_set_legacy_service(call):
+        """Shared function for both set_entity and set_variable legacy services."""
 
-        # _LOGGER.debug(f"[async_set_entity_legacy_service] entity: {entity}")
-        if entity and entity.platform == DOMAIN:
-            _LOGGER.debug("[async_set_entity_legacy_service] Updating variable")
-            pre_state = hass.states.get(entity_id=entity_id)
-            pre_attr = hass.states.get(entity_id=entity_id).attributes
-            _LOGGER.debug(
-                f"[async_set_entity_legacy_service] Previous state: "
-                f"{pre_state.as_dict()}"
-            )
-            _LOGGER.debug(
-                f"[async_set_entity_legacy_service] Previous attr: {pre_attr}"
-            )
-            if not call.data.get(ATTR_REPLACE_ATTRIBUTES, False):
-                if call.data.get(ATTR_ATTRIBUTES):
-                    new_attr = pre_attr | call.data.get(ATTR_ATTRIBUTES)
-                else:
-                    new_attr = pre_attr
-            else:
-                new_attr = call.data.get(ATTR_ATTRIBUTES)
-            _LOGGER.debug(f"[async_set_entity_legacy_service] Updated attr: {new_attr}")
-            hass.states.async_set(
-                entity_id=entity_id,
-                new_state=call.data.get(ATTR_VALUE),
-                attributes=new_attr,
-            )
-            _LOGGER.debug(
-                f"[async_set_entity_legacy_service] Post state: "
-                f"{hass.states.get(entity_id=entity_id).as_dict()}"
-            )
-        else:
-            _LOGGER.warning(
-                f"variable.set_entity Service Failed. Unknown Variable: {entity_id}"
-            )
+        _LOGGER.debug(f"[_async_set_legacy_service] call: {call}")
+        _LOGGER.debug(f"[_async_set_legacy_service] call data: {call.data}")
+
+        update_sensor_data = {
+            CONF_ENTITY_ID: [call.data.get(ATTR_ENTITY)],
+            ATTR_REPLACE_ATTRIBUTES: call.data.get(ATTR_REPLACE_ATTRIBUTES, False),
+        }
+        if call.data.get(ATTR_VALUE):
+            update_sensor_data.update({ATTR_VALUE: call.data.get(ATTR_VALUE)})
+        if call.data.get(ATTR_ATTRIBUTES):
+            update_sensor_data.update({ATTR_ATTRIBUTES: call.data.get(ATTR_ATTRIBUTES)})
+        _LOGGER.debug(
+            f"[_async_set_legacy_service] update_sensor_data: {update_sensor_data}"
+        )
+        await hass.services.async_call(
+            DOMAIN, SERVICE_UPDATE_SENSOR, service_data=update_sensor_data
+        )
 
     hass.services.async_register(
         DOMAIN,
@@ -260,10 +220,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-# async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-#    """Handle options update."""
-#
-#    _LOGGER.debug(f"[init update_listener] entry: {entry.as_dict()}")
-#    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -181,7 +181,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
                         entry, data=var_fields, options=entry.options
                     )
 
-                    hass.config_entries.async_reload(entry_id)
+                    hass.async_create_task(hass.config_entries.async_reload(entry_id))
 
                 else:
                     _LOGGER.error(

--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform, selector
 from homeassistant.helpers.entity import generate_entity_id
+from homeassistant.helpers.entity_registry import async_get
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import slugify
 import voluptuous as vol
@@ -40,6 +41,7 @@ from .const import (
     DEFAULT_RESTORE,
     DOMAIN,
 )
+from .recorder_history_prefilter import recorder_prefilter
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -160,25 +162,25 @@ class Variable(BinarySensorEntity, RestoreEntity):
             )
         else:
             self._attr_extra_state_attributes = None
-        self.entity_id = generate_entity_id(
-            ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
+
+        registry = async_get(self._hass)
+        current_entity_id = registry.async_get_entity_id(
+            PLATFORM, DOMAIN, self._attr_unique_id
         )
+        if current_entity_id is not None:
+            self.entity_id = current_entity_id
+        else:
+            self.entity_id = generate_entity_id(
+                ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
+            )
+        _LOGGER.debug(f"({self._attr_name}) entity_id: {self.entity_id}")
         if self._exclude_from_recorder:
             self.disable_recorder()
 
     def disable_recorder(self):
         if RECORDER_INSTANCE in self._hass.data:
-            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
             _LOGGER.info(f"({self._attr_name}) [disable_recorder] Disabling Recorder")
-            if self.entity_id:
-                try:
-                    ha_history_recorder.entity_filter._exclude_e.add(self.entity_id)
-                except AttributeError:
-                    pass
-                else:
-                    _LOGGER.debug(
-                        f"({self._attr_name}) [disable_recorder] _exclude_e: {ha_history_recorder.entity_filter._exclude_e}"
-                    )
+            recorder_prefilter.add_filter(self._hass, self.entity_id)
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""
@@ -214,17 +216,11 @@ class Variable(BinarySensorEntity, RestoreEntity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
-        if RECORDER_INSTANCE in self._hass.data:
-            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
-            if self.entity_id:
-                try:
-                    ha_history_recorder.entity_filter._exclude_e.discard(self.entity_id)
-                except AttributeError:
-                    pass
-                else:
-                    _LOGGER.debug(
-                        f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
-                    )
+        if RECORDER_INSTANCE in self._hass.data and self._exclude_from_recorder:
+            _LOGGER.debug(
+                f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
+            )
+            recorder_prefilter.remove_filter(self._hass, self.entity_id)
 
     @property
     def should_poll(self):

--- a/custom_components/variable/config_flow.py
+++ b/custom_components/variable/config_flow.py
@@ -178,10 +178,22 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_sensor_page_2(self, user_input=None):
         errors = {}
-        if user_input is not None:
+        if (
+            user_input is not None
+            or self.add_sensor_input.get(CONF_YAML_VARIABLE) is True
+        ):
             _LOGGER.debug(f"[New Sensor Page 2] page_1_input: {self.add_sensor_input}")
             _LOGGER.debug(f"[New Sensor Page 2] page_2_input: {user_input}")
 
+            if self.add_sensor_input.get(CONF_YAML_VARIABLE) is True:
+                user_input = {}
+                user_input.update({CONF_VALUE: self.add_sensor_input.get(CONF_VALUE)})
+                yaml_value_type = self.yaml_import_get_value_type()
+                _LOGGER.debug(
+                    f"[YAML] device_class: {self.add_sensor_input.get('attributes',dict()).get(CONF_DEVICE_CLASS)}"
+                )
+                _LOGGER.debug(f"[YAML] value_type: {yaml_value_type}")
+                self.add_sensor_input.update({CONF_VALUE_TYPE: yaml_value_type})
             try:
                 newval = value_to_type(
                     user_input.get(CONF_VALUE),
@@ -189,8 +201,13 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             except ValueError:
                 errors["base"] = "invalid_value_type"
+                if self.add_sensor_input.get(CONF_YAML_VARIABLE) is True:
+                    _LOGGER.error(
+                        "The value entered is not compatible with the selected device_class, setting value to None"
+                    )
+                    user_input.update({CONF_VALUE: None})
             else:
-                user_input[CONF_VALUE] = newval
+                user_input.update({CONF_VALUE: newval})
 
             _LOGGER.debug(
                 f"[New Sensor Page 2] value_type: {self.add_sensor_input.get(CONF_VALUE_TYPE)}"
@@ -199,7 +216,7 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 f"[New Sensor Page 2] type of value: {type(user_input.get(CONF_VALUE))}"
             )
 
-            if not errors:
+            if not errors or self.add_sensor_input.get(CONF_YAML_VARIABLE) is True:
                 if self.add_sensor_input is not None and self.add_sensor_input:
                     user_input.update(self.add_sensor_input)
                 if user_input is not None:
@@ -236,6 +253,28 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "value_type": self.add_sensor_input.get(CONF_VALUE_TYPE, "None"),
             },
         )
+
+    def yaml_import_get_value_type(self):
+        if (
+            self.add_sensor_input.get(CONF_ATTRIBUTES, {}).get(CONF_DEVICE_CLASS)
+            is None
+        ):
+            return None
+        elif self.add_sensor_input.get(CONF_ATTRIBUTES, {}).get(CONF_DEVICE_CLASS) in [
+            sensor.SensorDeviceClass.DATE
+        ]:
+            return "date"
+        elif self.add_sensor_input.get(CONF_ATTRIBUTES, {}).get(CONF_DEVICE_CLASS) in [
+            sensor.SensorDeviceClass.TIMESTAMP
+        ]:
+            return "datetime"
+        elif (
+            self.add_sensor_input.get(CONF_ATTRIBUTES, {}).get(CONF_DEVICE_CLASS)
+            == sensor.SensorDeviceClass.MONETARY
+        ):
+            return "string"
+        else:
+            return "number"
 
     def build_add_sensor_page_2(self):
         SENSOR_STATE_CLASS_SELECT_LIST = []

--- a/custom_components/variable/const.py
+++ b/custom_components/variable/const.py
@@ -24,6 +24,8 @@ CONF_EXCLUDE_FROM_RECORDER = "exclude_from_recorder"
 
 ATTR_ATTRIBUTES = "attributes"
 ATTR_ENTITY = "entity"
+ATTR_NATIVE_UNIT_OF_MEASUREMENT = "native_unit_of_measurement"
+ATTR_SUGGESTED_UNIT_OF_MEASUREMENT = "suggested_unit_of_measurement"
 ATTR_REPLACE_ATTRIBUTES = "replace_attributes"
 ATTR_VALUE = "value"
 ATTR_VARIABLE = "variable"

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -47,6 +47,7 @@ from .const import (
     DOMAIN,
 )
 from .helpers import value_to_type
+from .recorder_history_prefilter import recorder_prefilter
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -191,6 +192,18 @@ class Variable(RestoreSensor):
             except ValueError:
                 self._attr_native_value = None
 
+
+        registry = er.async_get(self._hass)
+        current_entity_id = registry.async_get_entity_id(
+            PLATFORM, DOMAIN, self._attr_unique_id
+        )
+        if current_entity_id is not None:
+            self.entity_id = current_entity_id
+        else:
+            self.entity_id = generate_entity_id(
+                ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
+            )
+        _LOGGER.debug(f"({self._attr_name}) entity_id: {self.entity_id}")
         _LOGGER.debug(
             f"({self._attr_name}) [init] _attr_state: {self._attr_state if hasattr(self, '_attr_state') else None}"
         )
@@ -200,29 +213,13 @@ class Variable(RestoreSensor):
         _LOGGER.debug(
             f"({self._attr_name}) [init] attributes: {self._attr_extra_state_attributes}"
         )
-        # self._hass.states.async_set(
-        #    entity_id=self.entity_id,
-        #    new_state=self._attr_state,
-        #    attributes=self._attr_extra_state_attributes,
-        # )
         if self._exclude_from_recorder:
             self.disable_recorder()
 
     def disable_recorder(self):
         if RECORDER_INSTANCE in self._hass.data:
-            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
             _LOGGER.info(f"({self._attr_name}) [disable_recorder] Disabling Recorder")
-            if self.entity_id:
-                try:
-                    ha_history_recorder.entity_filter._exclude_e.add(self.entity_id)
-                except AttributeError as e:
-                    _LOGGER.warning(
-                        f"({self._attr_name}) [disable_recorder] AttributeError trying to disable Recorder: {e}"
-                    )
-                else:
-                    _LOGGER.debug(
-                        f"({self._attr_name}) [disable_recorder] _exclude_e: {ha_history_recorder.entity_filter._exclude_e}"
-                    )
+            recorder_prefilter.add_filter(self._hass, self.entity_id)
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""
@@ -355,17 +352,11 @@ class Variable(RestoreSensor):
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
-        if RECORDER_INSTANCE in self._hass.data:
-            ha_history_recorder = self._hass.data[RECORDER_INSTANCE]
-            if self.entity_id:
-                try:
-                    ha_history_recorder.entity_filter._exclude_e.discard(self.entity_id)
-                except AttributeError:
-                    pass
-                else:
-                    _LOGGER.debug(
-                        f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
-                    )
+        if RECORDER_INSTANCE in self._hass.data and self._exclude_from_recorder:
+            _LOGGER.debug(
+                f"({self._attr_name}) Removing entity exclusion from recorder: {self.entity_id}"
+            )
+            recorder_prefilter.remove_filter(self._hass, self.entity_id)
 
     @property
     def should_poll(self):

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -165,6 +165,7 @@ class Variable(RestoreSensor):
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)
         self._attr_native_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
         self._attr_suggested_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
+
         self._attr_state_class = config.get(CONF_STATE_CLASS)
         if (
             config.get(CONF_ATTRIBUTES) is not None
@@ -176,6 +177,7 @@ class Variable(RestoreSensor):
             )
         else:
             self._attr_extra_state_attributes = None
+
         if config.get(CONF_VALUE) is None or (
             isinstance(config.get(CONF_VALUE), str)
             and config.get(CONF_VALUE).lower() in ["", "none", "unknown", "unavailable"]
@@ -188,6 +190,7 @@ class Variable(RestoreSensor):
                 )
             except ValueError:
                 self._attr_native_value = None
+
         _LOGGER.debug(
             f"({self._attr_name}) [init] _attr_state: {self._attr_state if hasattr(self, '_attr_state') else None}"
         )

--- a/custom_components/variable/services.yaml
+++ b/custom_components/variable/services.yaml
@@ -72,26 +72,26 @@ set_variable:
     # Key of the field
     variable:
       name: Variable ID
-      description: string (required) The name of the Sensor Variable to update
+      description: The name of the Sensor Variable to update [string] (required)
       required: true
       example: test_counter
       selector:
         text:
     value:
       name: New Value
-      description: any (optional) New value to set
+      description: "New value to set. If a device class and native unit of measurement is set: 1. This will update the value in the native unit of measurement not necessarily the displayed unit of measurement if they are different. 2. It will give an error if the value is not a supported type for the device class (ex. setting a string for a temperature device class) (optional)"
       example: 9
       selector:
         text:
     attributes:
       name: New Attributes
-      description: dictionary (optional) Attributes to set or update
+      description: Attributes to set or update [dictionary] (optional)
       example: "{'key': 'value'}"
       selector:
         object:
     replace_attributes:
       name: Replace Attributes
-      description: boolean (optional) Replace or merge current attributes (default false = merge)
+      description: Replace or merge current attributes [boolean] (optional) (default false = merge)
       required: true
       default: false
       example: "false"
@@ -104,7 +104,7 @@ set_entity:
   fields:
     entity:
       name: Entity ID
-      description: string (required) The entity_id of the Sensor Variable to update
+      description: The entity_id of the Sensor Variable to update [string] (required)
       example: sensor.test_sensor
       required: true
       selector:
@@ -113,19 +113,19 @@ set_entity:
           domain: sensor
     value:
       name: New Value
-      description: any (optional) New value to set
+      description: "New value to set. If a device class and native unit of measurement is set: 1. This will update the value in the native unit of measurement not necessarily the displayed unit of measurement if they are different. 2. It will give an error if the value is not a supported type for the device class (ex. setting a string for a temperature device class) (optional)"
       example: 9
       selector:
         text:
     attributes:
       name: New Attributes
-      description: dictionary (optional) Attributes to set or update
+      description: Attributes to set or update [dictionary] (optional)
       example: "{'key': 'value'}"
       selector:
         object:
     replace_attributes:
       name: Replace Attributes
-      description: boolean (optional) Replace or merge current attributes (default false = merge)
+      description: Replace or merge current attributes [boolean] (optional) (default false = merge)
       required: true
       default: false
       example: "false"

--- a/custom_components/variable/services.yaml
+++ b/custom_components/variable/services.yaml
@@ -8,7 +8,7 @@ update_sensor:
   fields:
     value:
       name: New Value
-      description: New value to set (optional)
+      description: "New value to set. if a device class and native unit of measurement is set:\n- This will update the value in the native unit of measurement not necessarily the displayed unit of measurement if they are different\n- It will give an error if the value is not a supported type for the device class (ex. setting a string for a temperature device class) (optional)"
       example: 9
       selector:
         text:

--- a/custom_components/variable/services.yaml
+++ b/custom_components/variable/services.yaml
@@ -8,7 +8,7 @@ update_sensor:
   fields:
     value:
       name: New Value
-      description: "New value to set. if a device class and native unit of measurement is set:\n- This will update the value in the native unit of measurement not necessarily the displayed unit of measurement if they are different\n- It will give an error if the value is not a supported type for the device class (ex. setting a string for a temperature device class) (optional)"
+      description: "New value to set. If a device class and native unit of measurement is set: 1. This will update the value in the native unit of measurement not necessarily the displayed unit of measurement if they are different. 2. It will give an error if the value is not a supported type for the device class (ex. setting a string for a temperature device class) (optional)"
       example: 9
       selector:
         text:


### PR DESCRIPTION
# Still in Draft

* Refactors how values are being stored for Sensor Variables.
* Changes the legacy services `set_entity` & `set_variable` to actually call the `update_sensor` service behind the scenes so that values can be stored properly

## Important: This is not a change but I feel needs to be explicitly noted
If a Sensor device class and native unit of measurement is set:

1.  The services will update the value in the native unit of measurement not the displayed unit of measurement if they are different
2.  The services will trigger an error if the updated value is not a supported type for the device class (ex. setting a string for a temperature device class)

Fixes #69 