### PR TITLE
Fix issues with sensor value changing on restart

### DIFF
--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -3,9 +3,15 @@ import json
 import logging
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_FRIENDLY_NAME, CONF_ICON, CONF_NAME, Platform
+from homeassistant.const import (
+    CONF_ENTITY_ID,
+    CONF_FRIENDLY_NAME,
+    CONF_ICON,
+    CONF_NAME,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 import voluptuous as vol
 
@@ -30,6 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_SET_VARIABLE_LEGACY = "set_variable"
 SERVICE_SET_ENTITY_LEGACY = "set_entity"
+SERVICE_UPDATE_SENSOR = "update_sensor"
 
 SERVICE_SET_VARIABLE_LEGACY_SCHEMA = vol.Schema(
     {
@@ -60,93 +67,37 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
     async def async_set_variable_legacy_service(call):
         """Handle calls to the set_variable legacy service."""
 
+        # _LOGGER.debug(f"[async_set_variable_legacy_service] Pre call data: {call.data}")
         ENTITY_ID_FORMAT = Platform.SENSOR + ".{}"
-
-        # _LOGGER.debug("[async_set_variable_legacy_service] call: " + str(call))
-
         entity_id = ENTITY_ID_FORMAT.format(call.data.get(ATTR_VARIABLE))
-        # _LOGGER.debug("[async_set_variable_legacy_service] entity_id: " + str(entity_id))
-        entity_registry = er.async_get(hass)
-        entity = entity_registry.async_get(entity_id)
-
-        # _LOGGER.debug("[async_set_variable_legacy_service] entity: " + str(entity))
-        if entity and entity.platform == DOMAIN:
-            _LOGGER.debug("[async_set_variable_legacy_service] Updating variable")
-            pre_state = hass.states.get(entity_id=entity_id)
-            pre_attr = hass.states.get(entity_id=entity_id).attributes
-            _LOGGER.debug(
-                f"[async_set_variable_legacy_service] Previous state: {pre_state.as_dict()}"
-            )
-            _LOGGER.debug(
-                f"[async_set_variable_legacy_service] Previous attr: {pre_attr}"
-            )
-            if not call.data.get(ATTR_REPLACE_ATTRIBUTES, False):
-                if call.data.get(ATTR_ATTRIBUTES):
-                    new_attr = pre_attr | call.data.get(ATTR_ATTRIBUTES)
-                else:
-                    new_attr = pre_attr
-            else:
-                new_attr = call.data.get(ATTR_ATTRIBUTES)
-            _LOGGER.debug(
-                f"[async_set_variable_legacy_service] Updated attr: {new_attr}"
-            )
-            hass.states.async_set(
-                entity_id=entity_id,
-                new_state=call.data.get(ATTR_VALUE),
-                attributes=new_attr,
-            )
-            _LOGGER.debug(
-                f"[async_set_variable_legacy_service] Post state: "
-                f"{hass.states.get(entity_id=entity_id).as_dict()}"
-            )
-        else:
-            _LOGGER.warning(
-                f"variable.set_variable Service Failed. Unknown Variable: {entity_id}"
-            )
+        call.data.update({ATTR_ENTITY: entity_id})
+        # _LOGGER.debug(f"[async_set_variable_legacy_service] Post call data: {call.data}")
+        await _async_set_legacy_service(call)
 
     async def async_set_entity_legacy_service(call):
         """Handle calls to the set_entity legacy service."""
 
-        # _LOGGER.debug(f"[async_set_entity_legacy_service] call: {call}")
+        # _LOGGER.debug(f"[async_set_entity_legacy_service] call data: {call.data}")
+        await _async_set_legacy_service(call)
 
-        entity_id: str = call.data.get(ATTR_ENTITY)
-        # _LOGGER.debug(f"[async_set_entity_legacy_service] entity_id: {entity_id}")
-        entity_registry = er.async_get(hass)
-        entity = entity_registry.async_get(entity_id)
+    async def _async_set_legacy_service(call):
+        """Shared function for both set_entity and set_variable legacy services."""
 
-        # _LOGGER.debug(f"[async_set_entity_legacy_service] entity: {entity}")
-        if entity and entity.platform == DOMAIN:
-            _LOGGER.debug("[async_set_entity_legacy_service] Updating variable")
-            pre_state = hass.states.get(entity_id=entity_id)
-            pre_attr = hass.states.get(entity_id=entity_id).attributes
-            _LOGGER.debug(
-                f"[async_set_entity_legacy_service] Previous state: "
-                f"{pre_state.as_dict()}"
-            )
-            _LOGGER.debug(
-                f"[async_set_entity_legacy_service] Previous attr: {pre_attr}"
-            )
-            if not call.data.get(ATTR_REPLACE_ATTRIBUTES, False):
-                if call.data.get(ATTR_ATTRIBUTES):
-                    new_attr = pre_attr | call.data.get(ATTR_ATTRIBUTES)
-                else:
-                    new_attr = pre_attr
-            else:
-                new_attr = call.data.get(ATTR_ATTRIBUTES)
-            _LOGGER.debug(f"[async_set_entity_legacy_service] Updated attr: {new_attr}")
-            hass.states.async_set(
-                entity_id=entity_id,
-                new_state=call.data.get(ATTR_VALUE),
-                attributes=new_attr,
-            )
-            _LOGGER.debug(
-                f"[async_set_entity_legacy_service] Post state: "
-                f"{hass.states.get(entity_id=entity_id).as_dict()}"
-            )
-        else:
-            _LOGGER.warning(
-                f"variable.set_entity Service Failed. Unknown Variable: {entity_id}"
-            )
+        # _LOGGER.debug(f"[_async_set_legacy_service] call data: {call.data}")
+        update_sensor_data = {
+            CONF_ENTITY_ID: [call.data.get(ATTR_ENTITY)],
+            ATTR_REPLACE_ATTRIBUTES: call.data.get(ATTR_REPLACE_ATTRIBUTES, False),
+        }
+        if call.data.get(ATTR_VALUE):
+            update_sensor_data.update({ATTR_VALUE: call.data.get(ATTR_VALUE)})
+        if call.data.get(ATTR_ATTRIBUTES):
+            update_sensor_data.update({ATTR_ATTRIBUTES: call.data.get(ATTR_ATTRIBUTES)})
+        _LOGGER.debug(
+            f"[_async_set_legacy_service] update_sensor_data: {update_sensor_data}"
+        )
+        await hass.services.async_call(
+            DOMAIN, SERVICE_UPDATE_SENSOR, service_data=update_sensor_data
+        )
 
     hass.services.async_register(
         DOMAIN,
@@ -211,7 +162,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
                 _LOGGER.debug(f"[YAML Update] entry_id: {entry_id}")
                 if entry_id:
                     entry = ent
-                    _LOGGER.debug(f"[YAML Update] entry before: {entry.as_dict()}")
+                    # _LOGGER.debug(f"[YAML Update] entry before: {entry.as_dict()}")
 
                     for m in dict(entry.data).keys():
                         var_fields.setdefault(m, entry.data[m])
@@ -235,7 +186,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up from a config entry."""
 
     entry.options = {}
-    _LOGGER.debug(f"[init async_setup_entry] entry: {entry.data}")
+    # _LOGGER.debug(f"[init async_setup_entry] entry: {entry.data}")
     hass.data.setdefault(DOMAIN, {})
     hass_data = dict(entry.data)
     hass.data[DOMAIN][entry.entry_id] = hass_data
@@ -260,10 +211,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-# async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-#    """Handle options update."""
-#
-#    _LOGGER.debug(f"[init update_listener] entry: {entry.as_dict()}")
-#    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -30,6 +30,7 @@ from .const import (
     CONF_EXCLUDE_FROM_RECORDER,
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
+    CONF_UPDATED,
     CONF_VALUE,
     CONF_VARIABLE_ID,
     CONF_YAML_VARIABLE,
@@ -63,7 +64,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 SERVICE_UPDATE_VARIABLE = "update_" + PLATFORM
 
-VARIABLE_ATTR_SETTINGS = {ATTR_FRIENDLY_NAME: "_attr_name", ATTR_ICON: "_attr_icon"}
+VARIABLE_ATTR_SETTINGS = {
+    ATTR_FRIENDLY_NAME: "_attr_name",
+    ATTR_ICON: "_attr_icon",
+    CONF_DEVICE_CLASS: "_attr_device_class",
+}
 
 
 async def async_setup_entry(
@@ -187,14 +192,15 @@ class Variable(BinarySensorEntity, RestoreEntity):
             _LOGGER.info(f"({self._attr_name}) Restoring after Reboot")
             state = await self.async_get_last_state()
             if state:
-                _LOGGER.debug(f"({self._attr_name}) Restored state: {state.as_dict()}")
+                # _LOGGER.debug(f"({self._attr_name}) Restored last state: {state.as_dict()}")
                 if (
                     hasattr(state, "attributes")
                     and state.attributes
                     and isinstance(state.attributes, MutableMapping)
                 ):
                     self._attr_extra_state_attributes = self._update_attr_settings(
-                        state.attributes.copy()
+                        state.attributes.copy(),
+                        just_pop=self._config.get(CONF_UPDATED, False),
                     )
                 if hasattr(state, "state"):
                     if state.state is None or (
@@ -211,6 +217,23 @@ class Variable(BinarySensorEntity, RestoreEntity):
                         self._attr_is_on = state.state
                 else:
                     self._attr_is_on = None
+            _LOGGER.debug(
+                f"({self._attr_name}) [restored] _attr_is_on: {self._attr_is_on}"
+            )
+            _LOGGER.debug(
+                f"({self._attr_name}) [restored] attributes: {self._attr_extra_state_attributes}"
+            )
+        if self._config.get(CONF_UPDATED, True):
+            self._config.update({CONF_UPDATED: False})
+            self._hass.config_entries.async_update_entry(
+                self._config_entry,
+                data=self._config,
+                options=self._config_entry.options,
+            )
+            _LOGGER.debug(
+                f"({self._attr_name}) Updated config_updated: "
+                + f"{self._config_entry.data.get(CONF_UPDATED)}"
+            )
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
@@ -236,16 +259,21 @@ class Variable(BinarySensorEntity, RestoreEntity):
         """Force update status of the entity."""
         return self._force_update
 
-    def _update_attr_settings(self, new_attributes=None):
+    def _update_attr_settings(self, new_attributes=None, just_pop=False):
         if new_attributes is not None:
+            _LOGGER.debug(
+                f"({self._attr_name}) [update_attr_settings] Updating Special Attributes"
+            )
             if isinstance(new_attributes, MutableMapping):
                 attributes = copy.deepcopy(new_attributes)
                 for attrib, setting in VARIABLE_ATTR_SETTINGS.items():
                     if attrib in attributes.keys():
-                        _LOGGER.debug(
-                            f"({self._attr_name}) [update_attr_settings] attrib: {attrib} / setting: {setting} / value: {attributes.get(attrib)}"
-                        )
-                        setattr(self, setting, attributes.pop(attrib, None))
+                        if just_pop:
+                            # _LOGGER.debug(f"({self._attr_name}) [update_attr_settings] just_pop / attrib: {attrib} / value: {attributes.get(attrib)}")
+                            attributes.pop(attrib, None)
+                        else:
+                            # _LOGGER.debug(f"({self._attr_name}) [update_attr_settings] attrib: {attrib} / setting: {setting} / value: {attributes.get(attrib)}")
+                            setattr(self, setting, attributes.pop(attrib, None))
                 return copy.deepcopy(attributes)
             else:
                 _LOGGER.error(

--- a/custom_components/variable/config_flow.py
+++ b/custom_components/variable/config_flow.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_EXCLUDE_FROM_RECORDER,
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
+    CONF_UPDATED,
     CONF_VALUE,
     CONF_VALUE_TYPE,
     CONF_VARIABLE_ID,
@@ -192,13 +193,6 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 user_input[CONF_VALUE] = newval
 
-            _LOGGER.debug(
-                f"[New Sensor Page 2] value_type: {self.add_sensor_input.get(CONF_VALUE_TYPE)}"
-            )
-            _LOGGER.debug(
-                f"[New Sensor Page 2] type of value: {type(user_input.get(CONF_VALUE))}"
-            )
-
             if not errors:
                 if self.add_sensor_input is not None and self.add_sensor_input:
                     user_input.update(self.add_sensor_input)
@@ -213,9 +207,9 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
 
         _LOGGER.debug(f"[New Sensor Page 2] Initial user_input: {user_input}")
-        _LOGGER.debug(
-            f"[New Sensor Page 2] device_class: {self.add_sensor_input.get(CONF_DEVICE_CLASS)}"
-        )
+        # _LOGGER.debug(
+        #    f"[New Sensor Page 2] device_class: {self.add_sensor_input.get(CONF_DEVICE_CLASS)}"
+        # )
 
         SENSOR_PAGE_2_SCHEMA = self.build_add_sensor_page_2()
 
@@ -366,7 +360,7 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 }
             )
 
-        _LOGGER.debug(f"[New Sensor Page 2] value_type: {value_type}")
+        # _LOGGER.debug(f"[New Sensor Page 2] value_type: {value_type}")
         self.add_sensor_input.update({CONF_VALUE_TYPE: value_type})
         return SENSOR_PAGE_2_SCHEMA
 
@@ -523,12 +517,12 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
             else:
                 user_input[CONF_VALUE] = newval
 
-            _LOGGER.debug(
-                f"[Sensor Options Page 2] value_type: {self.sensor_options_page_1.get(CONF_VALUE_TYPE)}"
-            )
-            _LOGGER.debug(
-                f"[Sensor Options Page 2] type of value: {type(user_input.get(CONF_VALUE))}"
-            )
+            # _LOGGER.debug(
+            #    f"[Sensor Options Page 2] value_type: {self.sensor_options_page_1.get(CONF_VALUE_TYPE)}"
+            # )
+            # _LOGGER.debug(
+            #    f"[Sensor Options Page 2] type of value: {type(user_input.get(CONF_VALUE))}"
+            # )
 
             if not errors:
                 if (
@@ -542,6 +536,7 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
                     for k, v in list(user_input.items()):
                         if v is None or (isinstance(v, str) and v.lower() == "none"):
                             user_input.pop(k, None)
+                user_input.update({CONF_UPDATED: True})
                 _LOGGER.debug(f"[Sensor Options Page 2] Final user_input: {user_input}")
                 self.config_entry.options = {}
 
@@ -554,9 +549,9 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
                 return self.async_create_entry(title="", data=user_input)
 
         _LOGGER.debug(f"[Sensor Options Page 2] Initial user_input: {user_input}")
-        _LOGGER.debug(
-            f"[Sensor Options Page 2] device_class: {self.sensor_options_page_1.get(CONF_DEVICE_CLASS)}"
-        )
+        # _LOGGER.debug(
+        #    f"[Sensor Options Page 2] device_class: {self.sensor_options_page_1.get(CONF_DEVICE_CLASS)}"
+        # )
 
         SENSOR_OPTIONS_PAGE_2_SCHEMA = self.build_sensor_options_page_2()
 
@@ -794,7 +789,7 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
         else:
             self.sensor_options_page_1[CONF_UNIT_OF_MEASUREMENT] = None
 
-        _LOGGER.debug(f"[Sensor Options Page 2] value_type: {value_type}")
+        # _LOGGER.debug(f"[Sensor Options Page 2] value_type: {value_type}")
         self.sensor_options_page_1.update({CONF_VALUE_TYPE: value_type})
         return SENSOR_OPTIONS_PAGE_2_SCHEMA
 
@@ -806,6 +801,7 @@ class VariableOptionsFlowHandler(config_entries.OptionsFlow):
             _LOGGER.debug(f"[Binary Sensor Options] user_input: {user_input}")
             for m in dict(self.config_entry.data).keys():
                 user_input.setdefault(m, self.config_entry.data[m])
+            user_input.update({CONF_UPDATED: True})
             _LOGGER.debug(f"[Binary Sensor Options] updated user_input: {user_input}")
             self.config_entry.options = {}
 

--- a/custom_components/variable/const.py
+++ b/custom_components/variable/const.py
@@ -21,6 +21,7 @@ CONF_VALUE_TYPE = "value_type"
 CONF_VARIABLE_ID = "variable_id"
 CONF_YAML_VARIABLE = "yaml_variable"
 CONF_EXCLUDE_FROM_RECORDER = "exclude_from_recorder"
+CONF_UPDATED = "config_updated"
 
 ATTR_ATTRIBUTES = "attributes"
 ATTR_ENTITY = "entity"

--- a/custom_components/variable/const.py
+++ b/custom_components/variable/const.py
@@ -24,6 +24,8 @@ CONF_EXCLUDE_FROM_RECORDER = "exclude_from_recorder"
 
 ATTR_ATTRIBUTES = "attributes"
 ATTR_ENTITY = "entity"
+ATTR_NATIVE_UNIT_OF_MEASUREMENT = "native_unit_of_measurement"
+ATTR_SUGGESTED_UNIT_OF_MEASUREMENT = "suggested_unit_of_measurement"
 ATTR_REPLACE_ATTRIBUTES = "replace_attributes"
 ATTR_VALUE = "value"
 ATTR_VARIABLE = "variable"

--- a/custom_components/variable/helpers.py
+++ b/custom_components/variable/helpers.py
@@ -22,12 +22,10 @@ def value_to_type(init_val, dest_type):  # noqa: C901
         isinstance(init_val, str)
         and init_val.lower() in ["", "none", "unknown", "unavailable"]
     ):
-        _LOGGER.debug(f"[value_to_type] value: {init_val}, returning None")
+        _LOGGER.debug(f"[value_to_type] return value: {init_val}, returning None")
         return None
 
-    _LOGGER.debug(
-        f"[value_to_type] initial value: {init_val}, initial type: {type(init_val)}, dest type: {dest_type}"
-    )
+    # _LOGGER.debug(f"[value_to_type] initial value: {init_val}, initial type: {type(init_val)}, dest type: {dest_type}")
     if isinstance(init_val, str):
         if dest_type is None or dest_type == "string":
             _LOGGER.debug(

--- a/custom_components/variable/services.yaml
+++ b/custom_components/variable/services.yaml
@@ -8,7 +8,7 @@ update_sensor:
   fields:
     value:
       name: New Value
-      description: New value to set (optional)
+      description: "New value to set. If a device class and native unit of measurement is set: 1. This will update the value in the native unit of measurement not necessarily the displayed unit of measurement if they are different. 2. It will give an error if the value is not a supported type for the device class (ex. setting a string for a temperature device class) (optional)"
       example: 9
       selector:
         text:
@@ -72,26 +72,26 @@ set_variable:
     # Key of the field
     variable:
       name: Variable ID
-      description: string (required) The name of the Sensor Variable to update
+      description: The name of the Sensor Variable to update [string] (required)
       required: true
       example: test_counter
       selector:
         text:
     value:
       name: New Value
-      description: any (optional) New value to set
+      description: "New value to set. If a device class and native unit of measurement is set: 1. This will update the value in the native unit of measurement not necessarily the displayed unit of measurement if they are different. 2. It will give an error if the value is not a supported type for the device class (ex. setting a string for a temperature device class) (optional)"
       example: 9
       selector:
         text:
     attributes:
       name: New Attributes
-      description: dictionary (optional) Attributes to set or update
+      description: Attributes to set or update [dictionary] (optional)
       example: "{'key': 'value'}"
       selector:
         object:
     replace_attributes:
       name: Replace Attributes
-      description: boolean (optional) Replace or merge current attributes (default false = merge)
+      description: Replace or merge current attributes [boolean] (optional) (default false = merge)
       required: true
       default: false
       example: "false"
@@ -104,7 +104,7 @@ set_entity:
   fields:
     entity:
       name: Entity ID
-      description: string (required) The entity_id of the Sensor Variable to update
+      description: The entity_id of the Sensor Variable to update [string] (required)
       example: sensor.test_sensor
       required: true
       selector:
@@ -113,19 +113,19 @@ set_entity:
           domain: sensor
     value:
       name: New Value
-      description: any (optional) New value to set
+      description: "New value to set. If a device class and native unit of measurement is set: 1. This will update the value in the native unit of measurement not necessarily the displayed unit of measurement if they are different. 2. It will give an error if the value is not a supported type for the device class (ex. setting a string for a temperature device class) (optional)"
       example: 9
       selector:
         text:
     attributes:
       name: New Attributes
-      description: dictionary (optional) Attributes to set or update
+      description: Attributes to set or update [dictionary] (optional)
       example: "{'key': 'value'}"
       selector:
         object:
     replace_attributes:
       name: Replace Attributes
-      description: boolean (optional) Replace or merge current attributes (default false = merge)
+      description: Replace or merge current attributes [boolean] (optional) (default false = merge)
       required: true
       default: false
       example: "false"


### PR DESCRIPTION
* Refactors how values are being stored for Sensor Variables.
* Changes the legacy services `set_entity` & `set_variable` to actually call the `update_sensor` service behind the scenes so that values can be stored properly
* Set `device_class`,`state_class`,`native_unit_of_measurement`, and `suggested_unit_of_measurement` in addition to `friendly_name` and `icon` if defined in the attributes, including on YAML import.

## Important: This is not a change but I feel needs to be explicitly noted
If a Sensor device class and native unit of measurement is set:

1.  The services will update the value in the native unit of measurement not the displayed unit of measurement if they are different
2.  The services will trigger an error if the updated value is not a supported type for the device class (ex. setting a string for a temperature device class)

Fixes #69 