### PR TITLE
Keep binary_sensor entity_id on Restart

### DIFF
--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform, selector
 from homeassistant.helpers.entity import generate_entity_id
+import homeassistant.helpers.entity_registry as er
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import slugify
 import voluptuous as vol
@@ -166,9 +167,17 @@ class Variable(BinarySensorEntity, RestoreEntity):
             )
         else:
             self._attr_extra_state_attributes = None
-        self.entity_id = generate_entity_id(
-            ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
+        registry = er.async_get(self._hass)
+        current_entity_id = registry.async_get_entity_id(
+            PLATFORM, DOMAIN, self._attr_unique_id
         )
+        if current_entity_id is not None:
+            self.entity_id = current_entity_id
+        else:
+            self.entity_id = generate_entity_id(
+                ENTITY_ID_FORMAT, self._variable_id, hass=self._hass
+            )
+        _LOGGER.debug(f"({self._attr_name}) [init] entity_id: {self.entity_id}")
         if self._exclude_from_recorder:
             self.disable_recorder()
 


### PR DESCRIPTION
This should keep the entity_id from potentially changing on restart.