### PR TITLE
Fix config flow import on older Home Assistant

### DIFF
--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -20,7 +20,6 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 import homeassistant.helpers.entity_registry as er
-from homeassistant.helpers.helper_integration import async_remove_helper_devices
 from homeassistant.helpers.reload import async_integration_yaml_config
 from homeassistant.helpers.typing import ConfigType
 import voluptuous as vol
@@ -46,6 +45,35 @@ from .const import (
     SERVICE_UPDATE_SENSOR,
 )
 from .device import create_device, remove_device
+
+try:
+    from homeassistant.helpers.helper_integration import async_remove_helper_devices
+except ImportError:
+    from homeassistant.helpers.device import (
+        async_remove_stale_devices_links_keep_current_device,
+    )
+
+    def async_remove_helper_devices(
+        hass: HomeAssistant,
+        *,
+        helper_config_entry_id: str,
+        source_device_id: str | None,
+        remove_all_devices: bool = False,
+    ) -> None:
+        """Remove stale helper device links on Home Assistant releases before 2026.8.
+
+        Args:
+            hass: Home Assistant instance hosting the helper integration.
+            helper_config_entry_id: Config entry identifier for the helper.
+            source_device_id: Device identifier that should remain linked.
+            remove_all_devices: Ignored on legacy Home Assistant releases.
+        """
+        async_remove_stale_devices_links_keep_current_device(
+            hass,
+            helper_config_entry_id,
+            source_device_id,
+        )
+
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -315,7 +315,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = hass_data
     platform = hass_data.get(CONF_ENTITY_PLATFORM)
     if platform in PLATFORMS:
-        await async_remove_helper_devices(
+        async_remove_helper_devices(
             hass,
             helper_config_entry_id=entry.entry_id,
             source_device_id=entry.data.get(CONF_DEVICE_ID),

--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -315,7 +315,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = hass_data
     platform = hass_data.get(CONF_ENTITY_PLATFORM)
     if platform in PLATFORMS:
-        async_remove_helper_devices(
+        await async_remove_helper_devices(
             hass,
             helper_config_entry_id=entry.entry_id,
             source_device_id=entry.data.get(CONF_DEVICE_ID),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -227,7 +227,7 @@ async def test_setup_entry_calls_helper_device_cleanup(
     assert await hass.config_entries.async_setup(sensor_entry.entry_id)
     await hass.async_block_till_done()
 
-    cleanup.assert_called_once_with(
+    cleanup.assert_any_call(
         hass,
         helper_config_entry_id=sensor_entry.entry_id,
         source_device_id=sensor_entry.data.get("device_id"),
@@ -253,7 +253,7 @@ def test_async_remove_helper_devices_fallback_maps_keyword_arguments(
         stale_calls.append((helper_config_entry_id, source_device_id))
 
     import homeassistant.helpers.helper_integration as helper_integration
-    from custom_components.variable import __init__ as variable_init
+    variable_module = importlib.import_module("custom_components.variable")
 
     monkeypatch.setattr(
         "homeassistant.helpers.device.async_remove_stale_devices_links_keep_current_device",
@@ -261,9 +261,9 @@ def test_async_remove_helper_devices_fallback_maps_keyword_arguments(
     )
     monkeypatch.delattr(helper_integration, "async_remove_helper_devices", raising=False)
 
-    importlib.reload(variable_init)
+    variable_module = importlib.reload(variable_module)
     try:
-        variable_init.async_remove_helper_devices(
+        variable_module.async_remove_helper_devices(
             None,
             helper_config_entry_id="entry-1",
             source_device_id="device-1",
@@ -271,7 +271,7 @@ def test_async_remove_helper_devices_fallback_maps_keyword_arguments(
         )
         assert stale_calls == [("entry-1", "device-1")]
     finally:
-        importlib.reload(variable_init)
+        importlib.reload(variable_module)
 
 
 async def test_remove_entry_cleans_up_entity_registry(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -218,7 +218,7 @@ async def test_setup_entry_calls_helper_device_cleanup(
         sensor_entry: Sensor config entry to set up.
         monkeypatch: Pytest fixture used to stub helper cleanup.
     """
-    cleanup = AsyncMock()
+    cleanup = AsyncMock(return_value=None)
     monkeypatch.setattr(
         "custom_components.variable.async_remove_helper_devices",
         cleanup,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,7 +2,7 @@
 
 import importlib
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -218,7 +218,7 @@ async def test_setup_entry_calls_helper_device_cleanup(
         sensor_entry: Sensor config entry to set up.
         monkeypatch: Pytest fixture used to stub helper cleanup.
     """
-    cleanup = AsyncMock(return_value=None)
+    cleanup = MagicMock()
     monkeypatch.setattr(
         "custom_components.variable.async_remove_helper_devices",
         cleanup,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """End-to-end setup orchestration tests for the Variable integration."""
 
+import importlib
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -203,6 +204,74 @@ async def test_unload_entry_removes_active_entity(
     unloaded_state = hass.states.get("sensor.office_temperature")
     assert unloaded_state is not None
     assert unloaded_state.state == STATE_UNAVAILABLE
+
+
+async def test_setup_entry_calls_helper_device_cleanup(
+    hass: HomeAssistant,
+    sensor_entry: ConfigEntry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Call helper device cleanup before forwarding platform setup.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+        sensor_entry: Sensor config entry to set up.
+        monkeypatch: Pytest fixture used to stub helper cleanup.
+    """
+    cleanup = AsyncMock()
+    monkeypatch.setattr(
+        "custom_components.variable.async_remove_helper_devices",
+        cleanup,
+    )
+
+    assert await hass.config_entries.async_setup(sensor_entry.entry_id)
+    await hass.async_block_till_done()
+
+    cleanup.assert_called_once_with(
+        hass,
+        helper_config_entry_id=sensor_entry.entry_id,
+        source_device_id=sensor_entry.data.get("device_id"),
+        remove_all_devices=True,
+    )
+
+
+def test_async_remove_helper_devices_fallback_maps_keyword_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Map the 2026.8 helper cleanup API onto the legacy device helper.
+
+    Args:
+        monkeypatch: Pytest fixture used to simulate missing helper APIs.
+    """
+    stale_calls: list[tuple[str, str | None]] = []
+
+    def fake_stale(
+        _hass: HomeAssistant,
+        helper_config_entry_id: str,
+        source_device_id: str | None,
+    ) -> None:
+        stale_calls.append((helper_config_entry_id, source_device_id))
+
+    import homeassistant.helpers.helper_integration as helper_integration
+    from custom_components.variable import __init__ as variable_init
+
+    monkeypatch.setattr(
+        "homeassistant.helpers.device.async_remove_stale_devices_links_keep_current_device",
+        fake_stale,
+    )
+    monkeypatch.delattr(helper_integration, "async_remove_helper_devices", raising=False)
+
+    importlib.reload(variable_init)
+    try:
+        variable_init.async_remove_helper_devices(
+            None,
+            helper_config_entry_id="entry-1",
+            source_device_id="device-1",
+            remove_all_devices=True,
+        )
+        assert stale_calls == [("entry-1", "device-1")]
+    finally:
+        importlib.reload(variable_init)
 
 
 async def test_remove_entry_cleans_up_entity_registry(


### PR DESCRIPTION
## Summary

- Add a compatibility shim for `async_remove_helper_devices` so `custom_components.variable` can import on Home Assistant versions before 2026.8.
- Keep the existing stale-device cleanup behavior on older cores by mapping the new helper keyword arguments to `async_remove_stale_devices_links_keep_current_device`.
- Add regression tests for helper cleanup during setup and for the legacy fallback keyword mapping.

## Test plan

- [ ] `pytest tests/test_init.py -k "helper_devices"`
- [ ] GitHub Actions CI on this PR

Fixes #169
