### PR TITLE
Fix recorder exclusion behavior

### DIFF
--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -49,9 +49,7 @@ from .device import create_device, remove_device
 try:
     from homeassistant.helpers.helper_integration import async_remove_helper_devices
 except ImportError:
-    from homeassistant.helpers.device import (
-        async_remove_stale_devices_links_keep_current_device,
-    )
+    from homeassistant.helpers.device import async_remove_stale_devices_links_keep_current_device
 
     def async_remove_helper_devices(
         hass: HomeAssistant,
@@ -118,28 +116,6 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
-
-
-async def _async_exclude_entity_from_recorder(hass: HomeAssistant, entity_id: str) -> None:
-    """Exclude an entity from recorder by updating recorder's internal config."""
-    try:
-        # Get current recorder config
-        recorder_config = hass.config.get("recorder", {})
-        exclude_entities = list(recorder_config.get("exclude_entities", []))
-
-        # Add entity if not already in list
-        if entity_id not in exclude_entities:
-            exclude_entities.append(entity_id)
-
-            # Try to update recorder's internal state if recorder is loaded
-            if "recorder" in hass.data:
-                recorder = hass.data.get("recorder", {})
-                if isinstance(recorder, dict):
-                    recorder["exclude_entities"] = exclude_entities
-
-            _LOGGER.debug(f"Entity excluded from recorder: {entity_id}")
-    except Exception as err:
-        _LOGGER.debug(f"Error excluding entity from recorder: {err}")
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType):

--- a/custom_components/variable/binary_sensor.py
+++ b/custom_components/variable/binary_sensor.py
@@ -31,7 +31,6 @@ from homeassistant.util import slugify
 import voluptuous as vol
 import yaml
 
-from . import _async_exclude_entity_from_recorder
 from .const import (
     ATTR_ATTRIBUTES,
     ATTR_REPLACE_ATTRIBUTES,
@@ -460,13 +459,6 @@ class Variable(BinarySensorEntity, RestoreEntity):  # type: ignore[misc]
 
 
 class VariableNoRecorder(Variable):
+    """Variable whose state attributes are not stored by Recorder."""
+
     _unrecorded_attributes = frozenset({MATCH_ALL})
-
-    async def async_added_to_hass(self) -> None:
-        """Run when entity is added to Home Assistant."""
-        await super().async_added_to_hass()
-
-        # Exclude from recorder automatically
-        await _async_exclude_entity_from_recorder(self.hass, self.entity_id)
-
-        _LOGGER.debug(f"({self._attr_name}) Excluded from recorder: {self.entity_id}")

--- a/custom_components/variable/device_tracker.py
+++ b/custom_components/variable/device_tracker.py
@@ -35,7 +35,6 @@ from homeassistant.util import slugify
 import voluptuous as vol
 import yaml
 
-from . import _async_exclude_entity_from_recorder
 from .const import (
     ATTR_ATTRIBUTES,
     ATTR_DELETE_IN_ZONES,
@@ -399,13 +398,6 @@ class Variable(RestoreEntity, TrackerEntity):
 
 
 class VariableNoRecorder(Variable):
+    """Variable whose state attributes are not stored by Recorder."""
+
     _unrecorded_attributes = frozenset({MATCH_ALL})
-
-    async def async_added_to_hass(self) -> None:
-        """Run when entity is added to Home Assistant."""
-        await super().async_added_to_hass()
-
-        # Exclude from recorder automatically
-        await _async_exclude_entity_from_recorder(self.hass, self.entity_id)
-
-        _LOGGER.debug(f"({self._attr_name}) Excluded from recorder: {self.entity_id}")

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -25,7 +25,6 @@ from homeassistant.util import slugify
 import voluptuous as vol
 import yaml
 
-from . import _async_exclude_entity_from_recorder
 from .const import (
     ATTR_ATTRIBUTES,
     ATTR_NATIVE_UNIT_OF_MEASUREMENT,
@@ -528,13 +527,6 @@ class Variable(RestoreSensor):
 
 
 class VariableNoRecorder(Variable):
+    """Variable whose state attributes are not stored by Recorder."""
+
     _unrecorded_attributes = frozenset({MATCH_ALL})
-
-    async def async_added_to_hass(self) -> None:
-        """Run when entity is added to Home Assistant."""
-        await super().async_added_to_hass()
-
-        # Exclude from recorder automatically
-        await _async_exclude_entity_from_recorder(self.hass, self.entity_id)
-
-        _LOGGER.debug(f"({self._attr_name}) Excluded from recorder: {self.entity_id}")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     CONF_ICON,
     CONF_NAME,
     CONF_UNIT_OF_MEASUREMENT,
+    MATCH_ALL,
     STATE_NOT_HOME,
     Platform,
 )
@@ -657,6 +658,8 @@ async def test_sensor_options_flow_updates_entry_and_live_entity(
     assert state is not None
     assert state.state == "26.5"
     assert state.attributes["source"] == "sensor-options"
+    assert state.state_info is not None
+    assert MATCH_ALL in state.state_info["unrecorded_attributes"]
 
 
 async def test_binary_sensor_options_update_entry_and_live_entity(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -253,6 +253,7 @@ def test_async_remove_helper_devices_fallback_maps_keyword_arguments(
         stale_calls.append((helper_config_entry_id, source_device_id))
 
     import homeassistant.helpers.helper_integration as helper_integration
+
     variable_module = importlib.import_module("custom_components.variable")
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
Fixes the broken Recorder exclusion behavior while preserving the existing **Exclude from Recorder** option. Variable entities now rely only on Home Assistant's supported entity-level unrecorded-attributes contract instead of attempting to mutate Recorder configuration at runtime.

## What Changed
- Removed the unsupported runtime helper that attempted to update Recorder exclusions after setup.
- Removed the per-platform calls to that helper for sensor, binary sensor, and device tracker variables.
- Retained `MATCH_ALL` in each `VariableNoRecorder` entity class so Recorder omits the entity's nonessential state attributes.
- Added a regression assertion that verifies the unrecorded-attributes contract remains active after an options-flow reload.

## Why
The previous helper read `hass.config` as though it were a mapping and updated `hass.data["recorder"]`, neither of which changes Recorder's active entity filter. This made the option's runtime behavior misleading and could raise errors during entity setup.

Using Home Assistant's entity-level `_unrecorded_attributes` contract preserves the existing configuration surface while providing the supported Recorder behavior.