### PR TITLE
Fix YAML variable reconciliation

### DIFF
--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -1,5 +1,6 @@
 """Variable implementation for Home Assistant."""
 
+import asyncio
 from collections.abc import Mapping
 import contextlib
 import copy
@@ -82,6 +83,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_SET_VARIABLE_LEGACY = "set_variable"
 SERVICE_SET_ENTITY_LEGACY = "set_entity"
+_YAML_RECONCILE_LOCK = f"{DOMAIN}_yaml_reconcile_lock"
 
 SERVICE_SET_VARIABLE_LEGACY_SCHEMA = vol.Schema(
     {
@@ -208,6 +210,27 @@ async def _async_process_yaml(
 
     Returns:
         True after all YAML imports, updates, and removals have completed.
+    """
+    reconcile_lock: asyncio.Lock = hass.data.setdefault(_YAML_RECONCILE_LOCK, asyncio.Lock())
+    async with reconcile_lock:
+        return await _async_reconcile_yaml(hass, config, wait_for_completion)
+
+
+async def _async_reconcile_yaml(
+    hass: HomeAssistant,
+    config: ConfigType,
+    wait_for_completion: bool,
+) -> bool:
+    """Reconcile YAML while the per-instance reconciliation lock is held.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+        config: Complete Home Assistant configuration containing this domain.
+        wait_for_completion: Whether to wait for config-entry lifecycle work.
+
+    Returns:
+        True after the requested YAML reconciliation work has been dispatched
+        or completed.
     """
     variables = copy.deepcopy(config.get(DOMAIN, {}))
     entries_by_variable_id: dict[str, list[ConfigEntry]] = {}

--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -230,15 +230,24 @@ async def _async_process_yaml(
                     var_fields.pop(key_empty)
 
             yaml_entries = yaml_entries_by_variable_id.get(var, [])
-            if not yaml_entries and var in entries_by_variable_id:
+            if any(
+                not entry.data.get(CONF_YAML_VARIABLE, False)
+                for entry in entries_by_variable_id.get(var, [])
+            ):
                 _LOGGER.error(
                     "[YAML] Cannot import %s because that variable ID belongs to a UI-created entry",
                     var,
                 )
+                for entry in yaml_entries:
+                    remove_entry = hass.config_entries.async_remove(entry.entry_id)
+                    if wait_for_completion:
+                        await remove_entry
+                    else:
+                        hass.async_create_task(remove_entry)
                 continue
 
             if not yaml_entries:
-                _LOGGER.warning(f"[YAML] Creating New Sensor Variable: {var}")
+                _LOGGER.warning("[YAML] Creating New Sensor Variable: %s", var)
                 import_flow = hass.config_entries.flow.async_init(
                     DOMAIN,
                     context={"source": SOURCE_IMPORT},
@@ -249,7 +258,7 @@ async def _async_process_yaml(
                 else:
                     hass.async_create_task(import_flow)
             else:
-                _LOGGER.info(f"[YAML] Updating Existing Sensor Variable: {var}")
+                _LOGGER.info("[YAML] Updating Existing Sensor Variable: %s", var)
                 entry = yaml_entries[0]
                 yaml_data = _yaml_entry_data(var, var_fields)
                 hass.config_entries.async_update_entry(entry, data=yaml_data)

--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -1,13 +1,16 @@
 """Variable implementation for Home Assistant."""
 
+from collections.abc import Mapping
 import contextlib
 import copy
-import json
 import logging
+from typing import Any
 
+from homeassistant.components import sensor as ha_sensor
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE,
+    CONF_DEVICE_CLASS,
     CONF_DEVICE_ID,
     CONF_ENTITY_ID,
     CONF_FRIENDLY_NAME,
@@ -36,6 +39,7 @@ from .const import (
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
     CONF_VALUE,
+    CONF_VALUE_TYPE,
     CONF_VARIABLE_ID,
     CONF_YAML_PRESENT,
     CONF_YAML_VARIABLE,
@@ -183,11 +187,38 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
     )
     hass.services.async_register(DOMAIN, SERVICE_RELOAD, _async_reload_service_handler)
 
-    return await _async_process_yaml(hass, config)
+    return await _async_process_yaml(hass, config, wait_for_completion=False)
 
 
-async def _async_process_yaml(hass: HomeAssistant, config: ConfigType) -> bool:
-    variables = json.loads(json.dumps(config.get(DOMAIN, {})))
+async def _async_process_yaml(
+    hass: HomeAssistant,
+    config: ConfigType,
+    *,
+    wait_for_completion: bool = True,
+) -> bool:
+    """Reconcile YAML-defined variables with their config entries.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+        config: Complete Home Assistant configuration containing this domain.
+        wait_for_completion: Whether to wait for config-entry lifecycle work.
+            This must be false during initial integration setup to avoid a
+            config-entry setup cycle.
+
+    Returns:
+        True after all YAML imports, updates, and removals have completed.
+    """
+    variables = copy.deepcopy(config.get(DOMAIN, {}))
+    entries_by_variable_id: dict[str, list[ConfigEntry]] = {}
+    yaml_entries_by_variable_id: dict[str, list[ConfigEntry]] = {}
+
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        variable_id = entry.data.get(CONF_VARIABLE_ID)
+        if not isinstance(variable_id, str):
+            continue
+        entries_by_variable_id.setdefault(variable_id, []).append(entry)
+        if entry.data.get(CONF_YAML_VARIABLE, False):
+            yaml_entries_by_variable_id.setdefault(variable_id, []).append(entry)
 
     for var, var_fields in variables.items():
         if var is not None:
@@ -198,73 +229,104 @@ async def _async_process_yaml(hass: HomeAssistant, config: ConfigType) -> bool:
                 if var_empty is None:
                     var_fields.pop(key_empty)
 
-            attr = var_fields.get(CONF_ATTRIBUTES, {})
-            icon = attr.pop(CONF_ICON, None)
-            name = var_fields.get(CONF_NAME, attr.pop(CONF_FRIENDLY_NAME, None))
-            attr.pop(CONF_FRIENDLY_NAME, None)
-
-            if var not in {
-                entry.data.get(CONF_VARIABLE_ID)
-                for entry in hass.config_entries.async_entries(DOMAIN)
-            }:
-                _LOGGER.warning(f"[YAML] Creating New Sensor Variable: {var}")
-                hass.async_create_task(
-                    hass.config_entries.flow.async_init(
-                        DOMAIN,
-                        context={"source": SOURCE_IMPORT},
-                        data={
-                            CONF_ENTITY_PLATFORM: Platform.SENSOR,
-                            CONF_VARIABLE_ID: var,
-                            CONF_NAME: name,
-                            CONF_VALUE: var_fields.get(CONF_VALUE),
-                            CONF_RESTORE: var_fields.get(CONF_RESTORE),
-                            CONF_FORCE_UPDATE: var_fields.get(CONF_FORCE_UPDATE),
-                            CONF_ATTRIBUTES: attr,
-                            CONF_ICON: icon,
-                        },
-                    )
+            yaml_entries = yaml_entries_by_variable_id.get(var, [])
+            if not yaml_entries and var in entries_by_variable_id:
+                _LOGGER.error(
+                    "[YAML] Cannot import %s because that variable ID belongs to a UI-created entry",
+                    var,
                 )
+                continue
+
+            if not yaml_entries:
+                _LOGGER.warning(f"[YAML] Creating New Sensor Variable: {var}")
+                import_flow = hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": SOURCE_IMPORT},
+                    data=_yaml_entry_data(var, var_fields),
+                )
+                if wait_for_completion:
+                    await import_flow
+                else:
+                    hass.async_create_task(import_flow)
             else:
                 _LOGGER.info(f"[YAML] Updating Existing Sensor Variable: {var}")
-
-                entry = None
-                entry_id = None
-                for ent in hass.config_entries.async_entries(DOMAIN):
-                    if var == ent.data.get(CONF_VARIABLE_ID):
-                        entry = ent
-                        entry_id = ent.entry_id
-                        break
-                # _LOGGER.debug(f"[YAML] entry_id: {entry_id}")
-                if entry_id and entry is not None:
-                    # _LOGGER.debug(f"[YAML] entry before: {entry.as_dict()}")
-
-                    for m in dict(entry.data).keys():
-                        var_fields.setdefault(m, entry.data[m])
-                    var_fields.update({CONF_YAML_PRESENT: True})
-                    # _LOGGER.debug(f"[YAML] Updated var_fields: {var_fields}")
-                    hass.config_entries.async_update_entry(entry, data=var_fields, options={})
-
-                    hass.async_create_task(hass.config_entries.async_reload(entry_id))
-
+                entry = yaml_entries[0]
+                yaml_data = _yaml_entry_data(var, var_fields)
+                hass.config_entries.async_update_entry(entry, data=yaml_data)
+                reload_entry = hass.config_entries.async_reload(entry.entry_id)
+                if wait_for_completion:
+                    await reload_entry
                 else:
-                    _LOGGER.error(f"[YAML] Update Error. Could not find entry_id for: {var}")
+                    hass.async_create_task(reload_entry)
 
     # Remove any config entries that were originally created from YAML imports
     # but are no longer present in the current YAML configuration.
-    try:
-        yaml_variable_ids = set(variables.keys())
-        for entry in hass.config_entries.async_entries(DOMAIN):
-            if entry.data.get(CONF_YAML_VARIABLE, False) is True:
-                var_id = entry.data.get(CONF_VARIABLE_ID)
-                if var_id and var_id not in yaml_variable_ids:
-                    _LOGGER.warning(
-                        f"[YAML] YAML Entry no longer exists in configuration, deleting entry: {var_id}"
-                    )
-                    hass.async_create_task(hass.config_entries.async_remove(entry.entry_id))
-    except Exception:
-        _LOGGER.exception("Error while cleaning up removed YAML variable entries")
+    yaml_variable_ids = set(variables)
+    for entries in yaml_entries_by_variable_id.values():
+        for entry in entries:
+            variable_id = entry.data.get(CONF_VARIABLE_ID)
+            if variable_id not in yaml_variable_ids:
+                _LOGGER.warning(
+                    "[YAML] YAML Entry no longer exists in configuration, deleting entry: %s",
+                    variable_id,
+                )
+                remove_entry = hass.config_entries.async_remove(entry.entry_id)
+                if wait_for_completion:
+                    await remove_entry
+                else:
+                    hass.async_create_task(remove_entry)
 
     return True
+
+
+def _yaml_entry_data(variable_id: str, variable_config: Mapping[str, Any]) -> dict[str, object]:
+    """Build the complete config-entry data owned by one YAML variable.
+
+    Args:
+        variable_id: YAML mapping key that identifies the variable.
+        variable_config: Configuration supplied for that variable.
+
+    Returns:
+        Config entry data which contains only the current YAML settings and
+        required YAML provenance fields.
+    """
+    yaml_config = copy.deepcopy(dict(variable_config))
+    attributes = yaml_config.pop(CONF_ATTRIBUTES, {})
+    icon = attributes.pop(CONF_ICON, None)
+    name = yaml_config.pop(CONF_NAME, attributes.pop(CONF_FRIENDLY_NAME, None))
+    attributes.pop(CONF_FRIENDLY_NAME, None)
+
+    entry_data: dict[str, object] = {
+        CONF_ENTITY_PLATFORM: Platform.SENSOR,
+        CONF_VARIABLE_ID: variable_id,
+        CONF_YAML_VARIABLE: True,
+        CONF_ATTRIBUTES: attributes,
+    }
+    for key in (
+        CONF_VALUE,
+        CONF_RESTORE,
+        CONF_FORCE_UPDATE,
+        CONF_EXCLUDE_FROM_RECORDER,
+    ):
+        value = yaml_config.get(key)
+        if value is not None:
+            entry_data[key] = value
+    if name is not None:
+        entry_data[CONF_NAME] = name
+    if icon is not None:
+        entry_data[CONF_ICON] = icon
+
+    device_class = attributes.get(CONF_DEVICE_CLASS)
+    if device_class == ha_sensor.SensorDeviceClass.DATE:
+        entry_data[CONF_VALUE_TYPE] = "date"
+    elif device_class == ha_sensor.SensorDeviceClass.TIMESTAMP:
+        entry_data[CONF_VALUE_TYPE] = "datetime"
+    elif device_class == ha_sensor.SensorDeviceClass.MONETARY:
+        entry_data[CONF_VALUE_TYPE] = "string"
+    elif device_class is not None:
+        entry_data[CONF_VALUE_TYPE] = "number"
+
+    return entry_data
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -416,8 +416,10 @@ def _yaml_entry_data(variable_id: str, variable_config: Mapping[str, Any]) -> di
     yaml_config = copy.deepcopy(dict(variable_config))
     attributes = yaml_config.pop(CONF_ATTRIBUTES, {})
     icon = attributes.pop(CONF_ICON, None)
-    name = yaml_config.pop(CONF_NAME, attributes.pop(CONF_FRIENDLY_NAME, None))
-    attributes.pop(CONF_FRIENDLY_NAME, None)
+    name = yaml_config.pop(CONF_NAME, None)
+    friendly_name = attributes.pop(CONF_FRIENDLY_NAME, None)
+    if name is None:
+        name = friendly_name
 
     entry_data: dict[str, object] = {
         CONF_ENTITY_PLATFORM: Platform.SENSOR,

--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -230,22 +230,25 @@ async def _async_dispatch_yaml_lifecycle(
     hass: HomeAssistant,
     lifecycle_work: Coroutine[Any, Any, object],
     wait_for_completion: bool,
-) -> None:
+) -> object | None:
     """Await lifecycle work or track it until background completion.
 
     Args:
         hass: Home Assistant instance that hosts the integration.
         lifecycle_work: Config-entry lifecycle operation to dispatch.
         wait_for_completion: Whether to wait for the operation to finish.
+
+    Returns:
+        The lifecycle result when waiting for completion, otherwise None.
     """
     if wait_for_completion:
-        await lifecycle_work
-        return
+        return await lifecycle_work
 
     pending_tasks: set[asyncio.Task[Any]] = hass.data.setdefault(_YAML_LIFECYCLE_TASKS, set())
     task: asyncio.Task[object] = hass.async_create_task(lifecycle_work)
     pending_tasks.add(task)
     task.add_done_callback(pending_tasks.discard)
+    return None
 
 
 async def _async_reconcile_yaml(
@@ -320,9 +323,31 @@ async def _async_reconcile_yaml(
                         wait_for_completion,
                     )
                 yaml_data = _yaml_entry_data(var, var_fields)
+                previous_data = copy.deepcopy(dict(entry.data))
                 hass.config_entries.async_update_entry(entry, data=yaml_data)
                 reload_entry = hass.config_entries.async_reload(entry.entry_id)
-                await _async_dispatch_yaml_lifecycle(hass, reload_entry, wait_for_completion)
+                reload_ok = await _async_dispatch_yaml_lifecycle(
+                    hass, reload_entry, wait_for_completion
+                )
+                if wait_for_completion and reload_ok is False:
+                    hass.config_entries.async_update_entry(entry, data=previous_data)
+                    try:
+                        rollback_ok = await hass.config_entries.async_reload(entry.entry_id)
+                    except HomeAssistantError:
+                        _LOGGER.exception(
+                            "[YAML] Error reloading %s after restoring its prior config-entry data",
+                            var,
+                        )
+                    else:
+                        if rollback_ok is False:
+                            _LOGGER.error(
+                                "[YAML] Reload returned false for %s after restoring its prior "
+                                "config-entry data",
+                                var,
+                            )
+                    raise HomeAssistantError(
+                        f"Failed to reload YAML variable {var}; restored its prior configuration"
+                    )
 
     # Remove any config entries that were originally created from YAML imports
     # but are no longer present in the current YAML configuration.

--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -260,6 +260,12 @@ async def _async_process_yaml(
             else:
                 _LOGGER.info("[YAML] Updating Existing Sensor Variable: %s", var)
                 entry = yaml_entries[0]
+                for duplicate_entry in yaml_entries[1:]:
+                    remove_entry = hass.config_entries.async_remove(duplicate_entry.entry_id)
+                    if wait_for_completion:
+                        await remove_entry
+                    else:
+                        hass.async_create_task(remove_entry)
                 yaml_data = _yaml_entry_data(var, var_fields)
                 hass.config_entries.async_update_entry(entry, data=yaml_data)
                 reload_entry = hass.config_entries.async_reload(entry.entry_id)
@@ -330,7 +336,10 @@ def _yaml_entry_data(variable_id: str, variable_config: Mapping[str, Any]) -> di
         entry_data[CONF_VALUE_TYPE] = "date"
     elif device_class == ha_sensor.SensorDeviceClass.TIMESTAMP:
         entry_data[CONF_VALUE_TYPE] = "datetime"
-    elif device_class == ha_sensor.SensorDeviceClass.MONETARY:
+    elif device_class in (
+        ha_sensor.SensorDeviceClass.MONETARY,
+        ha_sensor.SensorDeviceClass.ENUM,
+    ):
         entry_data[CONF_VALUE_TYPE] = "string"
     elif device_class is not None:
         entry_data[CONF_VALUE_TYPE] = "number"

--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -44,6 +44,7 @@ from .const import (
     CONF_YAML_PRESENT,
     CONF_YAML_VARIABLE,
     DEFAULT_REPLACE_ATTRIBUTES,
+    DEFAULT_RESTORE,
     DOMAIN,
     PLATFORMS,
     SERVICE_UPDATE_SENSOR,
@@ -316,6 +317,7 @@ def _yaml_entry_data(variable_id: str, variable_config: Mapping[str, Any]) -> di
         CONF_VARIABLE_ID: variable_id,
         CONF_YAML_VARIABLE: True,
         CONF_ATTRIBUTES: attributes,
+        CONF_RESTORE: DEFAULT_RESTORE,
     }
     for key in (
         CONF_VALUE,

--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -1,7 +1,7 @@
 """Variable implementation for Home Assistant."""
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Coroutine, Mapping
 import contextlib
 import copy
 import logging
@@ -84,6 +84,7 @@ _LOGGER = logging.getLogger(__name__)
 SERVICE_SET_VARIABLE_LEGACY = "set_variable"
 SERVICE_SET_ENTITY_LEGACY = "set_entity"
 _YAML_RECONCILE_LOCK = f"{DOMAIN}_yaml_reconcile_lock"
+_YAML_LIFECYCLE_TASKS = f"{DOMAIN}_yaml_lifecycle_tasks"
 
 SERVICE_SET_VARIABLE_LEGACY_SCHEMA = vol.Schema(
     {
@@ -213,7 +214,38 @@ async def _async_process_yaml(
     """
     reconcile_lock: asyncio.Lock = hass.data.setdefault(_YAML_RECONCILE_LOCK, asyncio.Lock())
     async with reconcile_lock:
+        if wait_for_completion:
+            pending_tasks: set[asyncio.Task[Any]] = hass.data.setdefault(
+                _YAML_LIFECYCLE_TASKS, set()
+            )
+            if pending_tasks:
+                results = await asyncio.gather(*tuple(pending_tasks), return_exceptions=True)
+                for result in results:
+                    if isinstance(result, BaseException):
+                        raise result
         return await _async_reconcile_yaml(hass, config, wait_for_completion)
+
+
+async def _async_dispatch_yaml_lifecycle(
+    hass: HomeAssistant,
+    lifecycle_work: Coroutine[Any, Any, object],
+    wait_for_completion: bool,
+) -> None:
+    """Await lifecycle work or track it until background completion.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+        lifecycle_work: Config-entry lifecycle operation to dispatch.
+        wait_for_completion: Whether to wait for the operation to finish.
+    """
+    if wait_for_completion:
+        await lifecycle_work
+        return
+
+    pending_tasks: set[asyncio.Task[Any]] = hass.data.setdefault(_YAML_LIFECYCLE_TASKS, set())
+    task: asyncio.Task[object] = hass.async_create_task(lifecycle_work)
+    pending_tasks.add(task)
+    task.add_done_callback(pending_tasks.discard)
 
 
 async def _async_reconcile_yaml(
@@ -263,11 +295,11 @@ async def _async_reconcile_yaml(
                     var,
                 )
                 for entry in yaml_entries:
-                    remove_entry = hass.config_entries.async_remove(entry.entry_id)
-                    if wait_for_completion:
-                        await remove_entry
-                    else:
-                        hass.async_create_task(remove_entry)
+                    await _async_dispatch_yaml_lifecycle(
+                        hass,
+                        hass.config_entries.async_remove(entry.entry_id),
+                        wait_for_completion,
+                    )
                 continue
 
             if not yaml_entries:
@@ -277,26 +309,20 @@ async def _async_reconcile_yaml(
                     context={"source": SOURCE_IMPORT},
                     data=_yaml_entry_data(var, var_fields),
                 )
-                if wait_for_completion:
-                    await import_flow
-                else:
-                    hass.async_create_task(import_flow)
+                await _async_dispatch_yaml_lifecycle(hass, import_flow, wait_for_completion)
             else:
                 _LOGGER.info("[YAML] Updating Existing Sensor Variable: %s", var)
                 entry = yaml_entries[0]
                 for duplicate_entry in yaml_entries[1:]:
-                    remove_entry = hass.config_entries.async_remove(duplicate_entry.entry_id)
-                    if wait_for_completion:
-                        await remove_entry
-                    else:
-                        hass.async_create_task(remove_entry)
+                    await _async_dispatch_yaml_lifecycle(
+                        hass,
+                        hass.config_entries.async_remove(duplicate_entry.entry_id),
+                        wait_for_completion,
+                    )
                 yaml_data = _yaml_entry_data(var, var_fields)
                 hass.config_entries.async_update_entry(entry, data=yaml_data)
                 reload_entry = hass.config_entries.async_reload(entry.entry_id)
-                if wait_for_completion:
-                    await reload_entry
-                else:
-                    hass.async_create_task(reload_entry)
+                await _async_dispatch_yaml_lifecycle(hass, reload_entry, wait_for_completion)
 
     # Remove any config entries that were originally created from YAML imports
     # but are no longer present in the current YAML configuration.
@@ -309,11 +335,11 @@ async def _async_reconcile_yaml(
                     "[YAML] YAML Entry no longer exists in configuration, deleting entry: %s",
                     variable_id,
                 )
-                remove_entry = hass.config_entries.async_remove(entry.entry_id)
-                if wait_for_completion:
-                    await remove_entry
-                else:
-                    hass.async_create_task(remove_entry)
+                await _async_dispatch_yaml_lifecycle(
+                    hass,
+                    hass.config_entries.async_remove(entry.entry_id),
+                    wait_for_completion,
+                )
 
     return True
 

--- a/custom_components/variable/__init__.py
+++ b/custom_components/variable/__init__.py
@@ -247,8 +247,61 @@ async def _async_dispatch_yaml_lifecycle(
     pending_tasks: set[asyncio.Task[Any]] = hass.data.setdefault(_YAML_LIFECYCLE_TASKS, set())
     task: asyncio.Task[object] = hass.async_create_task(lifecycle_work)
     pending_tasks.add(task)
-    task.add_done_callback(pending_tasks.discard)
+
+    def async_log_lifecycle_result(completed_task: asyncio.Task[object]) -> None:
+        """Remove completed work from tracking and log background failures."""
+        pending_tasks.discard(completed_task)
+        if completed_task.cancelled():
+            return
+        if error := completed_task.exception():
+            _LOGGER.error(
+                "[YAML] Background config-entry lifecycle work failed",
+                exc_info=(type(error), error, error.__traceback__),
+            )
+
+    task.add_done_callback(async_log_lifecycle_result)
     return None
+
+
+async def _async_update_yaml_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    variable_id: str,
+    yaml_data: Mapping[str, object],
+) -> None:
+    """Apply YAML data and restore the prior entry when reload is rejected.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+        entry: YAML-owned config entry being updated.
+        variable_id: YAML variable identifier used in diagnostics.
+        yaml_data: Complete replacement data built from the current YAML.
+
+    Raises:
+        HomeAssistantError: If Home Assistant rejects the updated entry reload.
+    """
+    previous_data = copy.deepcopy(dict(entry.data))
+    hass.config_entries.async_update_entry(entry, data=yaml_data)
+    if await hass.config_entries.async_reload(entry.entry_id) is not False:
+        return
+
+    hass.config_entries.async_update_entry(entry, data=previous_data)
+    try:
+        rollback_ok = await hass.config_entries.async_reload(entry.entry_id)
+    except HomeAssistantError:
+        _LOGGER.exception(
+            "[YAML] Error reloading %s after restoring its prior config-entry data",
+            variable_id,
+        )
+    else:
+        if rollback_ok is False:
+            _LOGGER.error(
+                "[YAML] Reload returned false for %s after restoring its prior config-entry data",
+                variable_id,
+            )
+    raise HomeAssistantError(
+        f"Failed to reload YAML variable {variable_id}; restored its prior configuration"
+    )
 
 
 async def _async_reconcile_yaml(
@@ -323,31 +376,11 @@ async def _async_reconcile_yaml(
                         wait_for_completion,
                     )
                 yaml_data = _yaml_entry_data(var, var_fields)
-                previous_data = copy.deepcopy(dict(entry.data))
-                hass.config_entries.async_update_entry(entry, data=yaml_data)
-                reload_entry = hass.config_entries.async_reload(entry.entry_id)
-                reload_ok = await _async_dispatch_yaml_lifecycle(
-                    hass, reload_entry, wait_for_completion
+                await _async_dispatch_yaml_lifecycle(
+                    hass,
+                    _async_update_yaml_entry(hass, entry, var, yaml_data),
+                    wait_for_completion,
                 )
-                if wait_for_completion and reload_ok is False:
-                    hass.config_entries.async_update_entry(entry, data=previous_data)
-                    try:
-                        rollback_ok = await hass.config_entries.async_reload(entry.entry_id)
-                    except HomeAssistantError:
-                        _LOGGER.exception(
-                            "[YAML] Error reloading %s after restoring its prior config-entry data",
-                            var,
-                        )
-                    else:
-                        if rollback_ok is False:
-                            _LOGGER.error(
-                                "[YAML] Reload returned false for %s after restoring its prior "
-                                "config-entry data",
-                                var,
-                            )
-                    raise HomeAssistantError(
-                        f"Failed to reload YAML variable {var}; restored its prior configuration"
-                    )
 
     # Remove any config entries that were originally created from YAML imports
     # but are no longer present in the current YAML configuration.

--- a/custom_components/variable/config_flow.py
+++ b/custom_components/variable/config_flow.py
@@ -387,7 +387,8 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
             },
         )
 
-    def yaml_import_get_value_type(self):
+    def yaml_import_get_value_type(self) -> str | None:
+        """Return the value type used to import the current YAML sensor."""
         if self.add_sensor_input.get(CONF_ATTRIBUTES, {}).get(CONF_DEVICE_CLASS) is None:
             return None
         elif self.add_sensor_input.get(CONF_ATTRIBUTES, {}).get(CONF_DEVICE_CLASS) in [
@@ -398,9 +399,9 @@ class VariableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
             sensor.SensorDeviceClass.TIMESTAMP
         ]:
             return "datetime"
-        elif (
-            self.add_sensor_input.get(CONF_ATTRIBUTES, {}).get(CONF_DEVICE_CLASS)
-            == sensor.SensorDeviceClass.MONETARY
+        elif self.add_sensor_input.get(CONF_ATTRIBUTES, {}).get(CONF_DEVICE_CLASS) in (
+            sensor.SensorDeviceClass.MONETARY,
+            sensor.SensorDeviceClass.ENUM,
         ):
             return "string"
         else:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -159,6 +159,7 @@ async def test_yaml_reload_creates_entities_before_service_returns(
         if entry.data.get(CONF_VARIABLE_ID) == variable_id
     )
     assert entry.data[CONF_YAML_VARIABLE] is True
+    assert entry.data[CONF_VALUE] == yaml_config[CONF_VALUE]
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == expected_state
@@ -262,9 +263,31 @@ async def test_yaml_reload_does_not_overwrite_ui_created_entry(
             CONF_ATTRIBUTES: {"source": "ui"},
         }
     )
+    yaml_entry = config_entry_factory(
+        {
+            CONF_ENTITY_PLATFORM: Platform.SENSOR,
+            CONF_VARIABLE_ID: "shared_variable",
+            CONF_NAME: "YAML Variable",
+            CONF_VALUE: "stale-yaml-value",
+            CONF_YAML_VARIABLE: True,
+            CONF_RESTORE: False,
+            CONF_FORCE_UPDATE: False,
+            CONF_ATTRIBUTES: {"source": "yaml"},
+        }
+    )
     assert await hass.config_entries.async_setup(ui_entry.entry_id)
+    assert await hass.config_entries.async_setup(yaml_entry.entry_id)
     await hass.async_block_till_done()
     original_data = dict(ui_entry.data)
+    registry = er.async_get(hass)
+    ui_registry_entry = er.async_entries_for_config_entry(registry, ui_entry.entry_id)[0]
+    yaml_registry_entry = er.async_entries_for_config_entry(registry, yaml_entry.entry_id)[0]
+    ui_state = hass.states.get(ui_registry_entry.entity_id)
+    yaml_state = hass.states.get(yaml_registry_entry.entity_id)
+    assert ui_state is not None
+    assert ui_state.state == "ui-value"
+    assert yaml_state is not None
+    assert yaml_state.state == "stale-yaml-value"
 
     with patch(
         "custom_components.variable.async_integration_yaml_config",
@@ -275,12 +298,16 @@ async def test_yaml_reload_does_not_overwrite_ui_created_entry(
     current_entry = hass.config_entries.async_get_entry(ui_entry.entry_id)
     assert current_entry is not None
     assert dict(current_entry.data) == original_data
+    assert hass.config_entries.async_get_entry(yaml_entry.entry_id) is None
     assert [entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN)] == [
         ui_entry.entry_id
     ]
-    state = hass.states.get("sensor.shared_variable")
-    assert state is not None
-    assert state.state == "ui-value"
+    assert registry.async_get(yaml_registry_entry.entity_id) is None
+    assert hass.states.get(yaml_registry_entry.entity_id) is None
+    assert registry.async_get(ui_registry_entry.entity_id) == ui_registry_entry
+    ui_state = hass.states.get(ui_registry_entry.entity_id)
+    assert ui_state is not None
+    assert ui_state.state == "ui-value"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -43,6 +43,34 @@ from custom_components.variable.const import (
 from tests.types import ConfigEntryFactory
 
 
+async def test_yaml_explicit_name_precedes_friendly_name_attribute(
+    hass: HomeAssistant,
+) -> None:
+    """Prefer an explicit name and omit the friendly-name attribute.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+    """
+    yaml_config = {
+        DOMAIN: {
+            "named_variable": {
+                CONF_NAME: "Explicit Name",
+                CONF_ATTRIBUTES: {
+                    CONF_FRIENDLY_NAME: "Attribute Name",
+                    "retained": True,
+                },
+            }
+        }
+    }
+
+    assert await async_setup_component(hass, DOMAIN, yaml_config)
+    await hass.async_block_till_done()
+
+    (entry,) = hass.config_entries.async_entries(DOMAIN)
+    assert entry.data[CONF_NAME] == "Explicit Name"
+    assert entry.data[CONF_ATTRIBUTES] == {"retained": True}
+
+
 async def test_yaml_setup_and_reload_manage_config_entries(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import pytest
@@ -109,6 +110,95 @@ async def test_yaml_setup_and_reload_manage_config_entries(
     assert hass.config_entries.async_get_entry(removed_entry.entry_id) is None
     assert hass.states.get("sensor.yaml_removed") is None
     assert er.async_get(hass).async_get("sensor.yaml_removed") is None
+
+
+@pytest.mark.parametrize(
+    ("failed_lifecycle_method", "expected_call_count"),
+    [("async_unload_entry", 1), ("async_setup_entry", 2)],
+    ids=["unload-failure", "setup-failure"],
+)
+async def test_yaml_reload_rolls_back_when_config_entry_reload_fails(
+    hass: HomeAssistant,
+    failed_lifecycle_method: str,
+    expected_call_count: int,
+) -> None:
+    """Restore config-entry data and live state after a failed YAML update.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+        failed_lifecycle_method: Integration lifecycle method that rejects the
+            first config-entry reload.
+        expected_call_count: Lifecycle calls expected after rollback recovery.
+    """
+    variable_id = "yaml_rollback"
+    initial_config = {
+        DOMAIN: {
+            variable_id: {
+                CONF_VALUE: "accepted",
+                CONF_RESTORE: False,
+                CONF_ATTRIBUTES: {"source": "accepted"},
+            }
+        }
+    }
+    assert await async_setup_component(hass, DOMAIN, initial_config)
+    await hass.async_block_till_done()
+
+    entry = next(
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.data.get(CONF_VARIABLE_ID) == variable_id
+    )
+    previous_data = dict(entry.data)
+    entity_id = f"sensor.{variable_id}"
+    initial_state = hass.states.get(entity_id)
+    assert initial_state is not None
+    assert initial_state.state == "accepted"
+
+    variable_module = importlib.import_module("custom_components.variable")
+    original_lifecycle_method = getattr(variable_module, failed_lifecycle_method)
+    call_count = 0
+
+    async def fail_first_lifecycle_call(
+        lifecycle_hass: HomeAssistant, lifecycle_entry: ConfigEntry
+    ) -> bool:
+        """Reject the update reload, then allow the rollback reload."""
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return False
+        return await original_lifecycle_method(lifecycle_hass, lifecycle_entry)
+
+    rejected_config = {
+        DOMAIN: {
+            variable_id: {
+                CONF_VALUE: "rejected",
+                CONF_RESTORE: False,
+                CONF_ATTRIBUTES: {"source": "rejected"},
+            }
+        }
+    }
+    with (
+        patch(
+            "custom_components.variable.async_integration_yaml_config",
+            new=AsyncMock(return_value=rejected_config),
+        ),
+        patch.object(
+            variable_module,
+            failed_lifecycle_method,
+            new=fail_first_lifecycle_call,
+        ),
+        pytest.raises(HomeAssistantError, match="restored its prior configuration"),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
+
+    assert call_count == expected_call_count
+    current_entry = hass.config_entries.async_get_entry(entry.entry_id)
+    assert current_entry is not None
+    assert current_entry.data == previous_data
+    recovered_state = hass.states.get(entity_id)
+    assert recovered_state is not None
+    assert recovered_state.state == "accepted"
+    assert recovered_state.attributes["source"] == "accepted"
 
 
 async def test_yaml_reload_removes_duplicate_yaml_entries(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -35,6 +35,7 @@ from custom_components.variable.const import (
     CONF_VARIABLE_ID,
     CONF_YAML_PRESENT,
     CONF_YAML_VARIABLE,
+    DEFAULT_RESTORE,
     DOMAIN,
 )
 from tests.types import ConfigEntryFactory
@@ -84,6 +85,7 @@ async def test_yaml_setup_and_reload_manage_config_entries(
         DOMAIN: {
             "yaml_temperature": {
                 CONF_VALUE: 24,
+                CONF_RESTORE: False,
                 "attributes": {"source": "reload"},
             }
         }
@@ -152,6 +154,7 @@ async def test_yaml_reload_removes_duplicate_yaml_entries(
                 DOMAIN: {
                     "duplicate_yaml": {
                         CONF_VALUE: "updated",
+                        CONF_RESTORE: False,
                         CONF_ATTRIBUTES: {"source": "reload"},
                     }
                 }
@@ -266,7 +269,6 @@ async def test_yaml_reload_creates_entities_before_service_returns(
     ("initial_config", "removed_key", "removed_attribute"),
     [
         pytest.param({CONF_VALUE: 12}, CONF_VALUE, None, id="value"),
-        pytest.param({CONF_RESTORE: False}, CONF_RESTORE, None, id="restore"),
         pytest.param({CONF_FORCE_UPDATE: True}, CONF_FORCE_UPDATE, None, id="force-update"),
         pytest.param(
             {CONF_EXCLUDE_FROM_RECORDER: True},
@@ -320,7 +322,7 @@ async def test_yaml_reload_removes_omitted_settings(
 
     with patch(
         "custom_components.variable.async_integration_yaml_config",
-        new=AsyncMock(return_value={DOMAIN: {variable_id: {}}}),
+        new=AsyncMock(return_value={DOMAIN: {variable_id: {CONF_RESTORE: False}}}),
     ):
         await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
 
@@ -335,6 +337,44 @@ async def test_yaml_reload_removes_omitted_settings(
         state = hass.states.get(f"sensor.{variable_id}")
         assert state is not None
         assert removed_attribute not in state.attributes
+
+
+async def test_yaml_reload_restores_default_when_restore_is_omitted(
+    hass: HomeAssistant,
+) -> None:
+    """Enable state restoration when reloaded YAML omits the restore setting.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+    """
+    variable_id = "yaml_restore_default"
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {DOMAIN: {variable_id: {CONF_RESTORE: False}}},
+    )
+    await hass.async_block_till_done()
+
+    restore_lookup = AsyncMock(return_value=None)
+    with (
+        patch(
+            "custom_components.variable.async_integration_yaml_config",
+            new=AsyncMock(return_value={DOMAIN: {variable_id: {}}}),
+        ),
+        patch(
+            "custom_components.variable.sensor.Variable.async_get_last_sensor_data",
+            new=restore_lookup,
+        ),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
+
+    entry = next(
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.data.get(CONF_VARIABLE_ID) == variable_id
+    )
+    assert entry.data[CONF_RESTORE] is DEFAULT_RESTORE
+    restore_lookup.assert_awaited_once_with()
 
 
 @pytest.mark.parametrize("yaml_entry_present", [False, True], ids=["ui-only", "with-yaml"])

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -325,6 +325,104 @@ async def test_concurrent_yaml_reloads_create_one_entry(
     assert state.state == "created-once"
 
 
+async def test_startup_import_and_reload_create_one_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Wait for a pending startup import before a reload snapshots entries.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+    """
+    variable_id = "startup_overlap"
+    yaml_config = {DOMAIN: {variable_id: {CONF_VALUE: "created-once"}}}
+    import_started = asyncio.Event()
+    allow_import = asyncio.Event()
+    original_async_init = hass.config_entries.flow.async_init
+
+    async def blocking_async_init(*args: Any, **kwargs: Any) -> Any:
+        """Pause the startup import at the config-entry creation boundary."""
+        import_started.set()
+        await allow_import.wait()
+        return await original_async_init(*args, **kwargs)
+
+    with (
+        patch(
+            "custom_components.variable.async_integration_yaml_config",
+            new=AsyncMock(return_value=yaml_config),
+        ),
+        patch.object(
+            hass.config_entries.flow,
+            "async_init",
+            new=AsyncMock(side_effect=blocking_async_init),
+        ) as async_init,
+    ):
+        assert await async_setup_component(hass, DOMAIN, yaml_config)
+        await import_started.wait()
+
+        reload_task = asyncio.create_task(
+            hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
+        )
+        try:
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            assert async_init.await_count == 1
+            assert not reload_task.done()
+        finally:
+            allow_import.set()
+            await reload_task
+
+    entries = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.data.get(CONF_VARIABLE_ID) == variable_id
+    ]
+    assert len(entries) == 1
+    assert len(er.async_entries_for_config_entry(er.async_get(hass), entries[0].entry_id)) == 1
+    state = hass.states.get(f"sensor.{variable_id}")
+    assert state is not None
+    assert state.state == "created-once"
+
+
+async def test_reload_propagates_pending_startup_import_failure(
+    hass: HomeAssistant,
+) -> None:
+    """Fail a reload when the startup lifecycle work it awaits fails.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+    """
+    yaml_config = {DOMAIN: {"failed_startup": {CONF_VALUE: "unused"}}}
+    import_started = asyncio.Event()
+    allow_failure = asyncio.Event()
+
+    async def failing_async_init(*args: Any, **kwargs: Any) -> Any:
+        """Pause and then fail the startup import."""
+        import_started.set()
+        await allow_failure.wait()
+        raise RuntimeError("startup import failed")
+
+    with (
+        patch(
+            "custom_components.variable.async_integration_yaml_config",
+            new=AsyncMock(return_value=yaml_config),
+        ),
+        patch.object(
+            hass.config_entries.flow,
+            "async_init",
+            new=AsyncMock(side_effect=failing_async_init),
+        ),
+    ):
+        assert await async_setup_component(hass, DOMAIN, yaml_config)
+        await import_started.wait()
+        reload_task = asyncio.create_task(
+            hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
+        )
+        await asyncio.sleep(0)
+        allow_failure.set()
+        with pytest.raises(RuntimeError, match="startup import failed"):
+            await reload_task
+
+
 @pytest.mark.parametrize(
     ("initial_config", "removed_key", "removed_attribute"),
     [

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """End-to-end setup orchestration tests for the Variable integration."""
 
+import asyncio
 import datetime
 import importlib
 from typing import Any
@@ -263,6 +264,65 @@ async def test_yaml_reload_creates_entities_before_service_returns(
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == expected_state
+
+
+async def test_concurrent_yaml_reloads_create_one_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Serialize concurrent reloads before they snapshot config entries.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+    """
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+
+    variable_id = "concurrent_yaml"
+    reload_config = {DOMAIN: {variable_id: {CONF_VALUE: "created-once"}}}
+    import_started = asyncio.Event()
+    allow_import = asyncio.Event()
+    original_async_init = hass.config_entries.flow.async_init
+
+    async def blocking_async_init(*args: Any, **kwargs: Any) -> Any:
+        """Pause the first import so the second reload overlaps it."""
+        import_started.set()
+        await allow_import.wait()
+        return await original_async_init(*args, **kwargs)
+
+    with (
+        patch(
+            "custom_components.variable.async_integration_yaml_config",
+            new=AsyncMock(return_value=reload_config),
+        ),
+        patch.object(
+            hass.config_entries.flow,
+            "async_init",
+            new=AsyncMock(side_effect=blocking_async_init),
+        ) as async_init,
+    ):
+        reloads = asyncio.gather(
+            hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True),
+            hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True),
+        )
+        try:
+            await import_started.wait()
+            await asyncio.sleep(0)
+            import_count_during_overlap = async_init.await_count
+        finally:
+            allow_import.set()
+            await reloads
+
+    assert import_count_during_overlap == 1
+
+    entries = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.data.get(CONF_VARIABLE_ID) == variable_id
+    ]
+    assert len(entries) == 1
+    assert len(er.async_entries_for_config_entry(er.async_get(hass), entries[0].entry_id)) == 1
+    state = hass.states.get(f"sensor.{variable_id}")
+    assert state is not None
+    assert state.state == "created-once"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -31,6 +31,7 @@ from custom_components.variable.const import (
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
     CONF_VALUE,
+    CONF_VALUE_TYPE,
     CONF_VARIABLE_ID,
     CONF_YAML_PRESENT,
     CONF_YAML_VARIABLE,
@@ -107,14 +108,92 @@ async def test_yaml_setup_and_reload_manage_config_entries(
     assert er.async_get(hass).async_get("sensor.yaml_removed") is None
 
 
+async def test_yaml_reload_removes_duplicate_yaml_entries(
+    hass: HomeAssistant,
+    config_entry_factory: ConfigEntryFactory,
+) -> None:
+    """Retain one updated YAML entry and fully remove its duplicate.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+        config_entry_factory: Factory that creates registered config entries.
+    """
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    entries = [
+        config_entry_factory(
+            {
+                CONF_ENTITY_PLATFORM: Platform.SENSOR,
+                CONF_VARIABLE_ID: "duplicate_yaml",
+                CONF_VALUE: value,
+                CONF_VALUE_TYPE: "string",
+                CONF_YAML_VARIABLE: True,
+                CONF_RESTORE: False,
+                CONF_FORCE_UPDATE: False,
+                CONF_ATTRIBUTES: {"source": source},
+            }
+        )
+        for value, source in (("retained", "canonical"), ("removed", "duplicate"))
+    ]
+    for entry in entries:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    registry_entries = [
+        er.async_entries_for_config_entry(registry, entry.entry_id)[0] for entry in entries
+    ]
+    for registry_entry in registry_entries:
+        assert hass.states.get(registry_entry.entity_id) is not None
+
+    with patch(
+        "custom_components.variable.async_integration_yaml_config",
+        new=AsyncMock(
+            return_value={
+                DOMAIN: {
+                    "duplicate_yaml": {
+                        CONF_VALUE: "updated",
+                        CONF_ATTRIBUTES: {"source": "reload"},
+                    }
+                }
+            }
+        ),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
+
+    retained_entry = hass.config_entries.async_get_entry(entries[0].entry_id)
+    assert retained_entry is not None
+    assert retained_entry.data[CONF_VALUE] == "updated"
+    assert hass.config_entries.async_get_entry(entries[1].entry_id) is None
+    assert [
+        entry.entry_id
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.data.get(CONF_VARIABLE_ID) == "duplicate_yaml"
+    ] == [entries[0].entry_id]
+    assert registry.async_get(registry_entries[1].entity_id) is None
+    assert hass.states.get(registry_entries[1].entity_id) is None
+    retained_registry_entry = registry.async_get(registry_entries[0].entity_id)
+    assert retained_registry_entry is not None
+    retained_state = hass.states.get(retained_registry_entry.entity_id)
+    assert retained_state is not None
+    assert retained_state.state == "updated"
+    assert retained_state.attributes["source"] == "reload"
+
+
 @pytest.mark.parametrize(
-    ("variable_id", "yaml_config", "entity_id", "expected_state"),
+    (
+        "variable_id",
+        "yaml_config",
+        "entity_id",
+        "expected_state",
+        "expected_value_type",
+    ),
     [
         pytest.param(
             "yaml_number",
             {CONF_VALUE: 42},
             "sensor.yaml_number",
             "42",
+            None,
             id="number",
         ),
         pytest.param(
@@ -125,7 +204,19 @@ async def test_yaml_setup_and_reload_manage_config_entries(
             },
             "sensor.yaml_date",
             "2026-08-05",
+            "date",
             id="native-date",
+        ),
+        pytest.param(
+            "yaml_enum",
+            {
+                CONF_VALUE: "heating",
+                CONF_ATTRIBUTES: {"device_class": "enum"},
+            },
+            "sensor.yaml_enum",
+            "heating",
+            "string",
+            id="enum",
         ),
     ],
 )
@@ -135,6 +226,7 @@ async def test_yaml_reload_creates_entities_before_service_returns(
     yaml_config: dict[str, Any],
     entity_id: str,
     expected_state: str,
+    expected_value_type: str | None,
 ) -> None:
     """Create YAML entities synchronously through the reload service.
 
@@ -144,6 +236,7 @@ async def test_yaml_reload_creates_entities_before_service_returns(
         yaml_config: Configuration for the imported YAML variable.
         entity_id: Expected entity identifier after import.
         expected_state: Expected state after import.
+        expected_value_type: Expected stored value type, if any.
     """
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -160,6 +253,10 @@ async def test_yaml_reload_creates_entities_before_service_returns(
     )
     assert entry.data[CONF_YAML_VARIABLE] is True
     assert entry.data[CONF_VALUE] == yaml_config[CONF_VALUE]
+    if expected_value_type is None:
+        assert CONF_VALUE_TYPE not in entry.data
+    else:
+        assert entry.data[CONF_VALUE_TYPE] == expected_value_type
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == expected_state
@@ -240,15 +337,18 @@ async def test_yaml_reload_removes_omitted_settings(
         assert removed_attribute not in state.attributes
 
 
+@pytest.mark.parametrize("yaml_entry_present", [False, True], ids=["ui-only", "with-yaml"])
 async def test_yaml_reload_does_not_overwrite_ui_created_entry(
     hass: HomeAssistant,
     config_entry_factory: ConfigEntryFactory,
+    yaml_entry_present: bool,
 ) -> None:
     """Leave a UI-created entry unchanged when YAML uses its variable ID.
 
     Args:
         hass: Home Assistant instance that hosts the integration.
         config_entry_factory: Factory that creates registered config entries.
+        yaml_entry_present: Whether a stale YAML-owned entry also exists.
     """
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     ui_entry = config_entry_factory(
@@ -263,31 +363,35 @@ async def test_yaml_reload_does_not_overwrite_ui_created_entry(
             CONF_ATTRIBUTES: {"source": "ui"},
         }
     )
-    yaml_entry = config_entry_factory(
-        {
-            CONF_ENTITY_PLATFORM: Platform.SENSOR,
-            CONF_VARIABLE_ID: "shared_variable",
-            CONF_NAME: "YAML Variable",
-            CONF_VALUE: "stale-yaml-value",
-            CONF_YAML_VARIABLE: True,
-            CONF_RESTORE: False,
-            CONF_FORCE_UPDATE: False,
-            CONF_ATTRIBUTES: {"source": "yaml"},
-        }
-    )
     assert await hass.config_entries.async_setup(ui_entry.entry_id)
-    assert await hass.config_entries.async_setup(yaml_entry.entry_id)
+    yaml_entry = None
+    if yaml_entry_present:
+        yaml_entry = config_entry_factory(
+            {
+                CONF_ENTITY_PLATFORM: Platform.SENSOR,
+                CONF_VARIABLE_ID: "shared_variable",
+                CONF_NAME: "YAML Variable",
+                CONF_VALUE: "stale-yaml-value",
+                CONF_YAML_VARIABLE: True,
+                CONF_RESTORE: False,
+                CONF_FORCE_UPDATE: False,
+                CONF_ATTRIBUTES: {"source": "yaml"},
+            }
+        )
+        assert await hass.config_entries.async_setup(yaml_entry.entry_id)
     await hass.async_block_till_done()
     original_data = dict(ui_entry.data)
     registry = er.async_get(hass)
     ui_registry_entry = er.async_entries_for_config_entry(registry, ui_entry.entry_id)[0]
-    yaml_registry_entry = er.async_entries_for_config_entry(registry, yaml_entry.entry_id)[0]
     ui_state = hass.states.get(ui_registry_entry.entity_id)
-    yaml_state = hass.states.get(yaml_registry_entry.entity_id)
     assert ui_state is not None
     assert ui_state.state == "ui-value"
-    assert yaml_state is not None
-    assert yaml_state.state == "stale-yaml-value"
+    yaml_registry_entry = None
+    if yaml_entry is not None:
+        yaml_registry_entry = er.async_entries_for_config_entry(registry, yaml_entry.entry_id)[0]
+        yaml_state = hass.states.get(yaml_registry_entry.entity_id)
+        assert yaml_state is not None
+        assert yaml_state.state == "stale-yaml-value"
 
     with patch(
         "custom_components.variable.async_integration_yaml_config",
@@ -298,12 +402,14 @@ async def test_yaml_reload_does_not_overwrite_ui_created_entry(
     current_entry = hass.config_entries.async_get_entry(ui_entry.entry_id)
     assert current_entry is not None
     assert dict(current_entry.data) == original_data
-    assert hass.config_entries.async_get_entry(yaml_entry.entry_id) is None
+    if yaml_entry is not None:
+        assert hass.config_entries.async_get_entry(yaml_entry.entry_id) is None
     assert [entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN)] == [
         ui_entry.entry_id
     ]
-    assert registry.async_get(yaml_registry_entry.entity_id) is None
-    assert hass.states.get(yaml_registry_entry.entity_id) is None
+    if yaml_registry_entry is not None:
+        assert registry.async_get(yaml_registry_entry.entity_id) is None
+        assert hass.states.get(yaml_registry_entry.entity_id) is None
     assert registry.async_get(ui_registry_entry.entity_id) == ui_registry_entry
     ui_state = hass.states.get(ui_registry_entry.entity_id)
     assert ui_state is not None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """End-to-end setup orchestration tests for the Variable integration."""
 
+import datetime
 import importlib
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -10,6 +11,9 @@ from homeassistant.const import (
     ATTR_GPS_ACCURACY,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
+    CONF_FRIENDLY_NAME,
+    CONF_ICON,
+    CONF_NAME,
     SERVICE_RELOAD,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -21,7 +25,11 @@ from homeassistant.setup import async_setup_component
 import pytest
 
 from custom_components.variable.const import (
+    CONF_ATTRIBUTES,
     CONF_ENTITY_PLATFORM,
+    CONF_EXCLUDE_FROM_RECORDER,
+    CONF_FORCE_UPDATE,
+    CONF_RESTORE,
     CONF_VALUE,
     CONF_VARIABLE_ID,
     CONF_YAML_PRESENT,
@@ -84,7 +92,6 @@ async def test_yaml_setup_and_reload_manage_config_entries(
         new=AsyncMock(return_value=reloaded_config),
     ):
         await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
-        await hass.async_block_till_done()
 
     current_entry = hass.config_entries.async_get_entry(temperature_entry.entry_id)
     assert current_entry is not None
@@ -98,6 +105,182 @@ async def test_yaml_setup_and_reload_manage_config_entries(
     assert hass.config_entries.async_get_entry(removed_entry.entry_id) is None
     assert hass.states.get("sensor.yaml_removed") is None
     assert er.async_get(hass).async_get("sensor.yaml_removed") is None
+
+
+@pytest.mark.parametrize(
+    ("variable_id", "yaml_config", "entity_id", "expected_state"),
+    [
+        pytest.param(
+            "yaml_number",
+            {CONF_VALUE: 42},
+            "sensor.yaml_number",
+            "42",
+            id="number",
+        ),
+        pytest.param(
+            "yaml_date",
+            {
+                CONF_VALUE: datetime.date(2026, 8, 5),
+                CONF_ATTRIBUTES: {"device_class": "date"},
+            },
+            "sensor.yaml_date",
+            "2026-08-05",
+            id="native-date",
+        ),
+    ],
+)
+async def test_yaml_reload_creates_entities_before_service_returns(
+    hass: HomeAssistant,
+    variable_id: str,
+    yaml_config: dict[str, Any],
+    entity_id: str,
+    expected_state: str,
+) -> None:
+    """Create YAML entities synchronously through the reload service.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+        variable_id: YAML variable ID to import.
+        yaml_config: Configuration for the imported YAML variable.
+        entity_id: Expected entity identifier after import.
+        expected_state: Expected state after import.
+    """
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+
+    with patch(
+        "custom_components.variable.async_integration_yaml_config",
+        new=AsyncMock(return_value={DOMAIN: {variable_id: yaml_config}}),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
+
+    entry = next(
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.data.get(CONF_VARIABLE_ID) == variable_id
+    )
+    assert entry.data[CONF_YAML_VARIABLE] is True
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == expected_state
+
+
+@pytest.mark.parametrize(
+    ("initial_config", "removed_key", "removed_attribute"),
+    [
+        pytest.param({CONF_VALUE: 12}, CONF_VALUE, None, id="value"),
+        pytest.param({CONF_RESTORE: False}, CONF_RESTORE, None, id="restore"),
+        pytest.param({CONF_FORCE_UPDATE: True}, CONF_FORCE_UPDATE, None, id="force-update"),
+        pytest.param(
+            {CONF_EXCLUDE_FROM_RECORDER: True},
+            CONF_EXCLUDE_FROM_RECORDER,
+            None,
+            id="exclude-from-recorder",
+        ),
+        pytest.param(
+            {CONF_NAME: "Configured Name"},
+            CONF_NAME,
+            None,
+            id="name",
+        ),
+        pytest.param(
+            {CONF_ATTRIBUTES: {CONF_FRIENDLY_NAME: "Configured Name"}},
+            CONF_NAME,
+            None,
+            id="friendly-name-attribute",
+        ),
+        pytest.param(
+            {CONF_ATTRIBUTES: {CONF_ICON: "mdi:thermometer"}},
+            CONF_ICON,
+            None,
+            id="icon-attribute",
+        ),
+        pytest.param(
+            {CONF_ATTRIBUTES: {"obsolete": "setting"}},
+            None,
+            "obsolete",
+            id="attribute",
+        ),
+    ],
+)
+async def test_yaml_reload_removes_omitted_settings(
+    hass: HomeAssistant,
+    initial_config: dict[str, Any],
+    removed_key: str | None,
+    removed_attribute: str | None,
+) -> None:
+    """Replace prior YAML data rather than retaining omitted settings.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+        initial_config: Initial settings that the later YAML omits.
+        removed_key: Config-entry key expected to be removed on reload.
+        removed_attribute: Entity attribute expected to be removed on reload.
+    """
+    variable_id = "yaml_settings"
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {variable_id: initial_config}})
+    await hass.async_block_till_done()
+
+    with patch(
+        "custom_components.variable.async_integration_yaml_config",
+        new=AsyncMock(return_value={DOMAIN: {variable_id: {}}}),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
+
+    entry = next(
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.data.get(CONF_VARIABLE_ID) == variable_id
+    )
+    if removed_key is not None:
+        assert removed_key not in entry.data
+    if removed_attribute is not None:
+        state = hass.states.get(f"sensor.{variable_id}")
+        assert state is not None
+        assert removed_attribute not in state.attributes
+
+
+async def test_yaml_reload_does_not_overwrite_ui_created_entry(
+    hass: HomeAssistant,
+    config_entry_factory: ConfigEntryFactory,
+) -> None:
+    """Leave a UI-created entry unchanged when YAML uses its variable ID.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+        config_entry_factory: Factory that creates registered config entries.
+    """
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    ui_entry = config_entry_factory(
+        {
+            CONF_ENTITY_PLATFORM: Platform.SENSOR,
+            CONF_VARIABLE_ID: "shared_variable",
+            CONF_NAME: "UI Variable",
+            CONF_VALUE: "ui-value",
+            CONF_YAML_VARIABLE: False,
+            CONF_RESTORE: False,
+            CONF_FORCE_UPDATE: False,
+            CONF_ATTRIBUTES: {"source": "ui"},
+        }
+    )
+    assert await hass.config_entries.async_setup(ui_entry.entry_id)
+    await hass.async_block_till_done()
+    original_data = dict(ui_entry.data)
+
+    with patch(
+        "custom_components.variable.async_integration_yaml_config",
+        new=AsyncMock(return_value={DOMAIN: {"shared_variable": {CONF_VALUE: "yaml-value"}}}),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_RELOAD, blocking=True)
+
+    current_entry = hass.config_entries.async_get_entry(ui_entry.entry_id)
+    assert current_entry is not None
+    assert dict(current_entry.data) == original_data
+    assert [entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN)] == [
+        ui_entry.entry_id
+    ]
+    state = hass.states.get("sensor.shared_variable")
+    assert state is not None
+    assert state.state == "ui-value"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -201,6 +201,93 @@ async def test_yaml_reload_rolls_back_when_config_entry_reload_fails(
     assert recovered_state.attributes["source"] == "accepted"
 
 
+@pytest.mark.parametrize(
+    ("failed_lifecycle_method", "expected_call_count"),
+    [("async_unload_entry", 1), ("async_setup_entry", 2)],
+    ids=["unload-failure", "setup-failure"],
+)
+async def test_startup_yaml_update_rolls_back_after_background_reload_failure(
+    hass: HomeAssistant,
+    failed_lifecycle_method: str,
+    expected_call_count: int,
+) -> None:
+    """Recover prior entry data and live state after startup reload failure.
+
+    Args:
+        hass: Home Assistant instance that hosts the integration.
+        failed_lifecycle_method: Integration lifecycle method that rejects the
+            first background reload.
+        expected_call_count: Lifecycle calls expected after rollback recovery.
+    """
+    variable_id = "startup_yaml_rollback"
+    initial_config = {
+        DOMAIN: {
+            variable_id: {
+                CONF_VALUE: "accepted",
+                CONF_RESTORE: False,
+                CONF_ATTRIBUTES: {"source": "accepted"},
+            }
+        }
+    }
+    assert await async_setup_component(hass, DOMAIN, initial_config)
+    await hass.async_block_till_done()
+
+    entry = next(
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.data.get(CONF_VARIABLE_ID) == variable_id
+    )
+    previous_data = dict(entry.data)
+
+    entity_id = f"sensor.{variable_id}"
+    initial_state = hass.states.get(entity_id)
+    assert initial_state is not None
+    assert initial_state.state == "accepted"
+
+    variable_module = importlib.import_module("custom_components.variable")
+    original_lifecycle_method = getattr(variable_module, failed_lifecycle_method)
+    call_count = 0
+
+    async def fail_first_lifecycle_call(
+        lifecycle_hass: HomeAssistant, lifecycle_entry: ConfigEntry
+    ) -> bool:
+        """Reject the startup update reload, then allow recovery."""
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return False
+        return await original_lifecycle_method(lifecycle_hass, lifecycle_entry)
+
+    rejected_config = {
+        DOMAIN: {
+            variable_id: {
+                CONF_VALUE: "rejected",
+                CONF_RESTORE: False,
+                CONF_ATTRIBUTES: {"source": "rejected"},
+            }
+        }
+    }
+    with patch.object(
+        variable_module,
+        failed_lifecycle_method,
+        new=fail_first_lifecycle_call,
+    ):
+        assert await variable_module._async_process_yaml(
+            hass, rejected_config, wait_for_completion=False
+        )
+        await hass.async_block_till_done()
+
+    assert call_count == expected_call_count
+    current_entry = hass.config_entries.async_get_entry(entry.entry_id)
+    assert current_entry is not None
+    assert current_entry.data == previous_data
+    recovered_state = hass.states.get(entity_id)
+    assert recovered_state is not None
+    assert recovered_state.state == "accepted"
+    assert recovered_state.attributes["source"] == "accepted"
+    assert not hass.data[variable_module._YAML_LIFECYCLE_TASKS]
+
+
 async def test_yaml_reload_removes_duplicate_yaml_entries(
     hass: HomeAssistant,
     config_entry_factory: ConfigEntryFactory,


### PR DESCRIPTION
## Summary

Reconciles YAML-defined variables with config entries so YAML reloads faithfully mirror the current configuration without taking ownership of UI-created variables.

## What Changed

- Prevents YAML IDs from overwriting UI-created entries and removes conflicting or duplicate YAML-owned entries.
- Rebuilds YAML-owned entry data from the current file so removed settings, names, icons, and attributes do not persist.
- Makes explicit `variable.reload` wait for config-entry imports, updates, and removals while preserving non-blocking initial setup.
- Rolls back entry data when a reload is rejected and preserves native YAML values, including dates.
- Treats enum sensors as string-valued and adds lifecycle, collision, rollback, and name-precedence regression coverage.

## Why

YAML configuration should be declarative: after a reload, an entity must match the file exactly, coexist safely with UI-managed entities, and provide a reliable completion boundary to callers.