### PR TITLE
Fix coverage publisher after v3.40 bump

### DIFF
--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -91,8 +91,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
 
       - name: Download coverage database
         env:
@@ -107,6 +105,5 @@ jobs:
         uses: py-cov-action/python-coverage-comment-action@7188638f871f721a365d644f505d1ff3df20d683 # v3.40
         with:
           GITHUB_TOKEN: ${{ github.token }}
-          ACTIVITY: save_coverage_data_files
           MINIMUM_GREEN: 90
           MINIMUM_ORANGE: 70


### PR DESCRIPTION
The pytest coverage publisher still passed ACTIVITY after bumping py-cov-action/python-coverage-comment-action to v3.40, which no longer accepts that input. Checkout also used persist-credentials: false, so the action could not push python-coverage-comment-action-data.\n\nThis keeps default checkout credentials on the publisher job and drops ACTIVITY so main coverage publishing can succeed.