### PR TITLE
Fix YAML unit_of_measurement treated as a custom attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Add the component `variable` to your configuration and declare the variables you
 | Variable ID           | `<key>:`                | `Yes`    |         | The desired id of the new sensor (ex. `test_variable` would create an entity_id of `sensor.test_variable`)                      |
 | Name                  | `name`                  | `No`     |         | Friendly name of the variable sensor                                                                                            |
 | Initial Value         | `value`                 | `No`     |         | Initial value/state of the variable. If `Restore on Restart` is `False`, the variable will reset to this value on every restart |
-| Initial Attributes    | `attributes`            | `No`     |         | Initial attributes of the variable. If `Restore on Restart` is `False`, the variable will reset to this value on every restart  |
+| Initial Attributes    | `attributes`            | `No`     |         | Initial attributes of the variable. If `Restore on Restart` is `False`, the variable will reset to this value on every restart. `device_class`, `state_class`, and `unit_of_measurement` are applied as native sensor properties. |
 | Restore on Restart    | `restore`               | `No`     | `True`  | If `True` will restore previous value on restart. If `False`, will reset to `Initial Value` and `Initial Attributes` on restart |
 | Force Update          | `force_update`          | `No`     | `False` | Variable's `last_updated` time will change with any service calls to update the variable even if the value does not change      |
 | Exclude from Recorder | `exclude_from_recorder` | `No`     | `False` | Excludes attributes from Recorder while preserving state history. Set to `True` for Variables with large attributes to prevent Recorder Errors. |
@@ -129,7 +129,12 @@ variable:
       previous: ''
     restore: true
   current_power_usage:
+    value: 1
     force_update: true
+    attributes:
+      state_class: measurement
+      device_class: power
+      unit_of_measurement: kW
 
   daily_download:
     value: 0

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -70,6 +70,20 @@ VARIABLE_ATTR_SETTINGS = {
     ATTR_SUGGESTED_UNIT_OF_MEASUREMENT: "_attr_suggested_unit_of_measurement",
 }
 
+_MISSING_SENSOR_SENTINELS = frozenset({"", "none", "unknown", "unavailable"})
+
+
+def _is_missing_sensor_value(value: object) -> bool:
+    """Return whether a restored or configured value represents absence.
+
+    Args:
+        value (object): Native value or unit to inspect.
+
+    Returns:
+        bool: True when the value is missing or a Home Assistant unavailable sentinel.
+    """
+    return value is None or (isinstance(value, str) and value.lower() in _MISSING_SENSOR_SENTINELS)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -202,16 +216,14 @@ class Variable(RestoreSensor):
             _LOGGER.info("(%s) Restoring after Reboot", self._attr_name)
             sensor = await self.async_get_last_sensor_data()
             if sensor and hasattr(sensor, "native_value"):
-                if sensor.native_value is None or (
-                    isinstance(sensor.native_value, str)
-                    and sensor.native_value.lower()
-                    in [
-                        "",
-                        "none",
-                        "unknown",
-                        "unavailable",
-                    ]
-                ):
+                restored_unit = getattr(sensor, "native_unit_of_measurement", None)
+                if _is_missing_sensor_value(restored_unit):
+                    self._attr_native_unit_of_measurement = None
+                else:
+                    self._attr_native_unit_of_measurement = restored_unit
+                    if self._attr_device_class in UNIT_CONVERTERS:
+                        self._attr_suggested_unit_of_measurement = restored_unit
+                if _is_missing_sensor_value(sensor.native_value):
                     self._attr_native_value = None
                 else:
                     try:
@@ -294,8 +306,11 @@ class Variable(RestoreSensor):
                 not getattr(self, "_attr_extra_state_attributes", None)
                 or self._attr_extra_state_attributes == {}
             ) and self._config.get(CONF_ATTRIBUTES):
+                # Last sensor extra data already restored native unit. Re-applying
+                # configured special attributes would overwrite that restored unit.
                 self._attr_extra_state_attributes = self._update_attr_settings(
-                    self._config.get(CONF_ATTRIBUTES)
+                    self._config.get(CONF_ATTRIBUTES),
+                    just_pop=sensor is not None,
                 )
                 _LOGGER.debug(
                     "(%s) [restored] applied config attributes: %s",
@@ -344,7 +359,7 @@ class Variable(RestoreSensor):
                 unit = attributes.get(ATTR_NATIVE_UNIT_OF_MEASUREMENT)
         if unit is None:
             unit = self._config.get(CONF_UNIT_OF_MEASUREMENT)
-        if unit is None or (isinstance(unit, str) and unit.lower() in ("", "none")):
+        if _is_missing_sensor_value(unit):
             return
 
         self._attr_native_unit_of_measurement = unit

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -65,6 +65,8 @@ VARIABLE_ATTR_SETTINGS = {
     CONF_DEVICE_CLASS: "_attr_device_class",
     CONF_STATE_CLASS: "_attr_state_class",
     ATTR_NATIVE_UNIT_OF_MEASUREMENT: "_attr_native_unit_of_measurement",
+    # YAML and update-service payloads use the public sensor attribute name.
+    CONF_UNIT_OF_MEASUREMENT: "_attr_native_unit_of_measurement",
     ATTR_SUGGESTED_UNIT_OF_MEASUREMENT: "_attr_suggested_unit_of_measurement",
 }
 
@@ -190,8 +192,8 @@ class Variable(RestoreSensor):
                 self._attr_native_value = value_to_type(configured_value, self._value_type)
             except ValueError:
                 self._attr_native_value = None
-        if config.get(CONF_DEVICE_CLASS) in UNIT_CONVERTERS:
-            self._attr_suggested_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
+        if self._attr_device_class in UNIT_CONVERTERS:
+            self._attr_suggested_unit_of_measurement = self._attr_native_unit_of_measurement
 
     async def async_added_to_hass(self) -> None:
         """Restore saved sensor state and attributes when configured."""
@@ -232,6 +234,10 @@ class Variable(RestoreSensor):
                 # name duplication across reboots.
                 restored_attributes = dict(state.attributes)
                 restored_attributes.pop(ATTR_FRIENDLY_NAME, None)
+                # Last state exposes the display unit. Native unit is restored
+                # separately from RestoreSensor extra data and must not be
+                # overwritten by a converted unit_of_measurement.
+                restored_attributes.pop(CONF_UNIT_OF_MEASUREMENT, None)
                 self._attr_extra_state_attributes = self._update_attr_settings(
                     restored_attributes,
                     just_pop=self._config.get(CONF_UPDATED, False),
@@ -304,6 +310,7 @@ class Variable(RestoreSensor):
                         self._attr_name,
                         err,
                     )
+        self._apply_missing_native_unit_from_config()
         if self._config.get(CONF_UPDATED, True):
             self._config.update({CONF_UPDATED: False})
             self._hass.config_entries.async_update_entry(
@@ -316,6 +323,35 @@ class Variable(RestoreSensor):
                 self._attr_name,
                 self._config_entry.data.get(CONF_UPDATED),
             )
+
+    def _apply_missing_native_unit_from_config(self) -> None:
+        """Fill a missing native unit from configured sensor unit attributes.
+
+        RestoreSensor extra data can restore ``None`` for YAML variables that
+        previously stored ``unit_of_measurement`` only as a custom attribute.
+        """
+        extra_attributes = self._attr_extra_state_attributes
+        if self._attr_native_unit_of_measurement is not None:
+            if isinstance(extra_attributes, MutableMapping):
+                extra_attributes.pop(CONF_UNIT_OF_MEASUREMENT, None)
+            return
+
+        attributes = self._config.get(CONF_ATTRIBUTES)
+        unit = None
+        if isinstance(attributes, MutableMapping):
+            unit = attributes.get(CONF_UNIT_OF_MEASUREMENT)
+            if unit is None:
+                unit = attributes.get(ATTR_NATIVE_UNIT_OF_MEASUREMENT)
+        if unit is None:
+            unit = self._config.get(CONF_UNIT_OF_MEASUREMENT)
+        if unit is None or (isinstance(unit, str) and unit.lower() in ("", "none")):
+            return
+
+        self._attr_native_unit_of_measurement = unit
+        if isinstance(extra_attributes, MutableMapping):
+            extra_attributes.pop(CONF_UNIT_OF_MEASUREMENT, None)
+        if self._attr_device_class in UNIT_CONVERTERS:
+            self._attr_suggested_unit_of_measurement = unit
 
     @property
     def should_poll(self) -> bool:

--- a/custom_components/variable/sensor.py
+++ b/custom_components/variable/sensor.py
@@ -71,6 +71,12 @@ VARIABLE_ATTR_SETTINGS = {
 }
 
 _MISSING_SENSOR_SENTINELS = frozenset({"", "none", "unknown", "unavailable"})
+_UNIT_SETTINGS = frozenset(
+    {
+        "_attr_native_unit_of_measurement",
+        "_attr_suggested_unit_of_measurement",
+    }
+)
 
 
 def _is_missing_sensor_value(value: object) -> bool:
@@ -83,6 +89,20 @@ def _is_missing_sensor_value(value: object) -> bool:
         bool: True when the value is missing or a Home Assistant unavailable sentinel.
     """
     return value is None or (isinstance(value, str) and value.lower() in _MISSING_SENSOR_SENTINELS)
+
+
+def _normalize_sensor_unit(value: object) -> str | None:
+    """Return a unit string, or None for missing sentinels.
+
+    Args:
+        value (object): Configured, restored, or service-provided unit.
+
+    Returns:
+        str | None: The unit string, or ``None`` when the value is missing.
+    """
+    if _is_missing_sensor_value(value) or not isinstance(value, str):
+        return None
+    return value
 
 
 async def async_setup_entry(
@@ -180,7 +200,9 @@ class Variable(RestoreSensor):
         self._exclude_from_recorder = config.get(CONF_EXCLUDE_FROM_RECORDER)
         self._value_type = config.get(CONF_VALUE_TYPE)
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)
-        self._attr_native_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
+        self._attr_native_unit_of_measurement = _normalize_sensor_unit(
+            config.get(CONF_UNIT_OF_MEASUREMENT)
+        )
         self._attr_suggested_unit_of_measurement = None
         self._attr_state_class = config.get(CONF_STATE_CLASS)
         if (device_id := config.get(CONF_DEVICE_ID)) is not None:
@@ -216,13 +238,12 @@ class Variable(RestoreSensor):
             _LOGGER.info("(%s) Restoring after Reboot", self._attr_name)
             sensor = await self.async_get_last_sensor_data()
             if sensor and hasattr(sensor, "native_value"):
-                restored_unit = getattr(sensor, "native_unit_of_measurement", None)
-                if _is_missing_sensor_value(restored_unit):
-                    self._attr_native_unit_of_measurement = None
-                else:
-                    self._attr_native_unit_of_measurement = restored_unit
-                    if self._attr_device_class in UNIT_CONVERTERS:
-                        self._attr_suggested_unit_of_measurement = restored_unit
+                restored_unit = _normalize_sensor_unit(
+                    getattr(sensor, "native_unit_of_measurement", None)
+                )
+                self._attr_native_unit_of_measurement = restored_unit
+                if restored_unit is not None and self._attr_device_class in UNIT_CONVERTERS:
+                    self._attr_suggested_unit_of_measurement = restored_unit
                 if _is_missing_sensor_value(sensor.native_value):
                     self._attr_native_value = None
                 else:
@@ -346,7 +367,7 @@ class Variable(RestoreSensor):
         previously stored ``unit_of_measurement`` only as a custom attribute.
         """
         extra_attributes = self._attr_extra_state_attributes
-        if self._attr_native_unit_of_measurement is not None:
+        if not _is_missing_sensor_value(self._attr_native_unit_of_measurement):
             if isinstance(extra_attributes, MutableMapping):
                 extra_attributes.pop(CONF_UNIT_OF_MEASUREMENT, None)
             return
@@ -360,13 +381,14 @@ class Variable(RestoreSensor):
         if unit is None:
             unit = self._config.get(CONF_UNIT_OF_MEASUREMENT)
         if _is_missing_sensor_value(unit):
+            self._attr_native_unit_of_measurement = None
             return
 
-        self._attr_native_unit_of_measurement = unit
+        self._attr_native_unit_of_measurement = _normalize_sensor_unit(unit)
         if isinstance(extra_attributes, MutableMapping):
             extra_attributes.pop(CONF_UNIT_OF_MEASUREMENT, None)
         if self._attr_device_class in UNIT_CONVERTERS:
-            self._attr_suggested_unit_of_measurement = unit
+            self._attr_suggested_unit_of_measurement = self._attr_native_unit_of_measurement
 
     @property
     def should_poll(self) -> bool:
@@ -408,7 +430,10 @@ class Variable(RestoreSensor):
                         if just_pop:
                             attributes.pop(attrib, None)
                         else:
-                            setattr(self, setting, attributes.pop(attrib, None))
+                            value = attributes.pop(attrib, None)
+                            if setting in _UNIT_SETTINGS:
+                                value = _normalize_sensor_unit(value)
+                            setattr(self, setting, value)
                 return copy.deepcopy(attributes)
             _LOGGER.error(
                 "(%s) AttributeError: Attributes must be a dictionary: %s",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -580,6 +580,44 @@ async def test_yaml_reload_creates_entities_before_service_returns(
     assert state.state == expected_state
 
 
+async def test_yaml_power_sensor_uses_attribute_unit_as_native_unit(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Treat YAML unit_of_measurement as the sensor native unit.
+
+    Args:
+        hass (HomeAssistant): Home Assistant instance that hosts the integration.
+        caplog (pytest.LogCaptureFixture): Pytest fixture capturing log output.
+    """
+    yaml_config = {
+        DOMAIN: {
+            "variable_test_del_15m": {
+                CONF_VALUE: 1,
+                CONF_RESTORE: False,
+                CONF_EXCLUDE_FROM_RECORDER: False,
+                CONF_ATTRIBUTES: {
+                    "state_class": "measurement",
+                    "device_class": "power",
+                    "unit_of_measurement": "kW",
+                },
+            }
+        }
+    }
+
+    with caplog.at_level("WARNING"):
+        assert await async_setup_component(hass, DOMAIN, yaml_config)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.variable_test_del_15m")
+    assert state is not None
+    assert state.state == "1"
+    assert state.attributes["device_class"] == "power"
+    assert state.attributes["state_class"] == "measurement"
+    assert state.attributes["unit_of_measurement"] == "kW"
+    assert "native unit of measurement 'None'" not in caplog.text
+
+
 async def test_concurrent_yaml_reloads_create_one_entry(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,10 +2,22 @@
 
 from datetime import date
 
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_FRIENDLY_NAME, CONF_DEVICE, CONF_DEVICE_ID, CONF_NAME, Platform
+from homeassistant.const import (
+    ATTR_FRIENDLY_NAME,
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_DEVICE,
+    CONF_DEVICE_CLASS,
+    CONF_DEVICE_ID,
+    CONF_NAME,
+    CONF_UNIT_OF_MEASUREMENT,
+    Platform,
+    UnitOfPower,
+)
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity_platform import async_get_platforms
 import pytest
 from pytest_homeassistant_custom_component.common import mock_restore_cache_with_extra_data
 
@@ -28,6 +40,28 @@ from custom_components.variable.const import (
 )
 from custom_components.variable.sensor import Variable
 from tests.types import ConfigEntryFactory
+
+NATIVE_UNIT_NONE_WARNING = "native unit of measurement 'None'"
+
+
+def _loaded_sensor(hass: HomeAssistant, entity_id: str) -> Variable:
+    """Return the loaded Variable sensor entity for an entity ID.
+
+    Args:
+        hass (HomeAssistant): Home Assistant test instance.
+        entity_id (str): Entity identifier to look up.
+
+    Returns:
+        Variable: The loaded sensor entity.
+
+    Raises:
+        AssertionError: If the entity is not registered on the sensor platform.
+    """
+    for platform in async_get_platforms(hass, DOMAIN):
+        entity = platform.entities.get(entity_id)
+        if isinstance(entity, Variable):
+            return entity
+    raise AssertionError(f"Variable sensor {entity_id} was not loaded")
 
 
 @pytest.mark.parametrize(
@@ -540,3 +574,225 @@ async def test_increment_converts_numeric_string_native_value(
     native_value = sensor._attr_native_value
     assert isinstance(native_value, float)
     assert native_value == 4.75
+
+
+async def test_attribute_unit_of_measurement_is_native_unit(
+    hass: HomeAssistant,
+    config_entry_factory: ConfigEntryFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Promote YAML-style unit_of_measurement attributes to the native unit.
+
+    Args:
+        hass (HomeAssistant): Home Assistant test instance.
+        config_entry_factory (ConfigEntryFactory): Factory for test configuration entries.
+        caplog (pytest.LogCaptureFixture): Pytest fixture capturing log output.
+    """
+    entity_id = "sensor.variable_test_del_15m"
+    entry = config_entry_factory(
+        {
+            CONF_ENTITY_PLATFORM: Platform.SENSOR,
+            CONF_VARIABLE_ID: "variable_test_del_15m",
+            CONF_VALUE: 1,
+            CONF_VALUE_TYPE: "number",
+            CONF_YAML_VARIABLE: True,
+            CONF_RESTORE: False,
+            CONF_FORCE_UPDATE: False,
+            CONF_ATTRIBUTES: {
+                "state_class": SensorStateClass.MEASUREMENT,
+                CONF_DEVICE_CLASS: SensorDeviceClass.POWER,
+                CONF_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT,
+            },
+        }
+    )
+
+    with caplog.at_level("WARNING"):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "1"
+    assert state.attributes[CONF_DEVICE_CLASS] == SensorDeviceClass.POWER
+    assert state.attributes["state_class"] == SensorStateClass.MEASUREMENT
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfPower.KILO_WATT
+
+    sensor = _loaded_sensor(hass, entity_id)
+    assert sensor.native_unit_of_measurement == UnitOfPower.KILO_WATT
+    assert sensor.device_class == SensorDeviceClass.POWER
+    assert sensor.state_class == SensorStateClass.MEASUREMENT
+    extra_attributes = sensor._attr_extra_state_attributes
+    assert extra_attributes is not None
+    assert CONF_UNIT_OF_MEASUREMENT not in extra_attributes
+    assert NATIVE_UNIT_NONE_WARNING not in caplog.text
+
+
+async def test_restore_keeps_native_unit_when_display_unit_differs(
+    hass: HomeAssistant,
+    config_entry_factory: ConfigEntryFactory,
+) -> None:
+    """Keep RestoreSensor native units when last state has a converted display unit.
+
+    Args:
+        hass (HomeAssistant): Home Assistant test instance.
+        config_entry_factory (ConfigEntryFactory): Factory for test configuration entries.
+    """
+    entity_id = "sensor.restored_power"
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(
+                    entity_id,
+                    "1",
+                    {
+                        CONF_DEVICE_CLASS: SensorDeviceClass.POWER,
+                        "state_class": SensorStateClass.MEASUREMENT,
+                        ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.WATT,
+                    },
+                ),
+                {
+                    "native_value": "1",
+                    "native_unit_of_measurement": UnitOfPower.KILO_WATT,
+                },
+            )
+        ],
+    )
+    entry = config_entry_factory(
+        {
+            CONF_ENTITY_PLATFORM: Platform.SENSOR,
+            CONF_VARIABLE_ID: "restored_power",
+            CONF_VALUE: 0,
+            CONF_VALUE_TYPE: "number",
+            CONF_YAML_VARIABLE: True,
+            CONF_RESTORE: True,
+            CONF_FORCE_UPDATE: False,
+            CONF_ATTRIBUTES: {
+                "state_class": SensorStateClass.MEASUREMENT,
+                CONF_DEVICE_CLASS: SensorDeviceClass.POWER,
+                CONF_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT,
+            },
+        }
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    sensor = _loaded_sensor(hass, entity_id)
+    assert sensor.native_unit_of_measurement == UnitOfPower.KILO_WATT
+    extra_attributes = sensor._attr_extra_state_attributes
+    assert extra_attributes is not None
+    assert CONF_UNIT_OF_MEASUREMENT not in extra_attributes
+    assert ATTR_UNIT_OF_MEASUREMENT not in extra_attributes
+
+
+async def test_restore_replaces_missing_native_unit_from_config_attributes(
+    hass: HomeAssistant,
+    config_entry_factory: ConfigEntryFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Recover a YAML unit when RestoreSensor extra data stored native unit as None.
+
+    Args:
+        hass (HomeAssistant): Home Assistant test instance.
+        config_entry_factory (ConfigEntryFactory): Factory for test configuration entries.
+        caplog (pytest.LogCaptureFixture): Pytest fixture capturing log output.
+    """
+    entity_id = "sensor.legacy_power"
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(
+                    entity_id,
+                    "1",
+                    {
+                        CONF_DEVICE_CLASS: SensorDeviceClass.POWER,
+                        "state_class": SensorStateClass.MEASUREMENT,
+                        ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT,
+                    },
+                ),
+                {
+                    "native_value": "1",
+                    "native_unit_of_measurement": None,
+                },
+            )
+        ],
+    )
+    entry = config_entry_factory(
+        {
+            CONF_ENTITY_PLATFORM: Platform.SENSOR,
+            CONF_VARIABLE_ID: "legacy_power",
+            CONF_VALUE: 1,
+            CONF_VALUE_TYPE: "number",
+            CONF_YAML_VARIABLE: True,
+            CONF_RESTORE: False,
+            CONF_FORCE_UPDATE: False,
+            CONF_ATTRIBUTES: {
+                "state_class": SensorStateClass.MEASUREMENT,
+                CONF_DEVICE_CLASS: SensorDeviceClass.POWER,
+                CONF_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT,
+            },
+        }
+    )
+
+    with caplog.at_level("WARNING"):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    sensor = _loaded_sensor(hass, entity_id)
+    assert sensor.native_unit_of_measurement == UnitOfPower.KILO_WATT
+    extra_attributes = sensor._attr_extra_state_attributes
+    assert extra_attributes is not None
+    assert CONF_UNIT_OF_MEASUREMENT not in extra_attributes
+    assert NATIVE_UNIT_NONE_WARNING not in caplog.text
+
+
+async def test_update_sensor_promotes_unit_of_measurement_attribute(
+    hass: HomeAssistant,
+    config_entry_factory: ConfigEntryFactory,
+) -> None:
+    """Apply unit_of_measurement from an update-service attribute payload.
+
+    Args:
+        hass (HomeAssistant): Home Assistant test instance.
+        config_entry_factory (ConfigEntryFactory): Factory for test configuration entries.
+    """
+    entity_id = "sensor.service_power"
+    entry = config_entry_factory(
+        {
+            CONF_ENTITY_PLATFORM: Platform.SENSOR,
+            CONF_VARIABLE_ID: "service_power",
+            CONF_VALUE: 2,
+            CONF_VALUE_TYPE: "number",
+            CONF_YAML_VARIABLE: False,
+            CONF_RESTORE: False,
+            CONF_FORCE_UPDATE: False,
+        }
+    )
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_UPDATE_SENSOR,
+        {
+            "entity_id": [entity_id],
+            ATTR_ATTRIBUTES: {
+                CONF_DEVICE_CLASS: SensorDeviceClass.POWER,
+                "state_class": SensorStateClass.MEASUREMENT,
+                CONF_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT,
+            },
+        },
+        blocking=True,
+    )
+
+    sensor = _loaded_sensor(hass, entity_id)
+    assert sensor.native_unit_of_measurement == UnitOfPower.KILO_WATT
+    assert sensor.device_class == SensorDeviceClass.POWER
+    extra_attributes = sensor._attr_extra_state_attributes
+    assert extra_attributes is not None
+    assert CONF_UNIT_OF_MEASUREMENT not in extra_attributes
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfPower.KILO_WATT

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -23,6 +23,7 @@ from pytest_homeassistant_custom_component.common import mock_restore_cache_with
 
 from custom_components.variable.const import (
     ATTR_ATTRIBUTES,
+    ATTR_NATIVE_UNIT_OF_MEASUREMENT,
     ATTR_REPLACE_ATTRIBUTES,
     ATTR_VALUE_DELTA,
     CONF_ATTRIBUTES,
@@ -595,7 +596,7 @@ async def test_attribute_unit_of_measurement_is_native_unit(
             CONF_VARIABLE_ID: "variable_test_del_15m",
             CONF_VALUE: 1,
             CONF_VALUE_TYPE: "number",
-            CONF_YAML_VARIABLE: True,
+            CONF_YAML_VARIABLE: False,
             CONF_RESTORE: False,
             CONF_FORCE_UPDATE: False,
             CONF_ATTRIBUTES: {
@@ -664,7 +665,7 @@ async def test_restore_keeps_native_unit_when_display_unit_differs(
             CONF_VARIABLE_ID: "restored_power",
             CONF_VALUE: 0,
             CONF_VALUE_TYPE: "number",
-            CONF_YAML_VARIABLE: True,
+            CONF_YAML_VARIABLE: False,
             CONF_RESTORE: True,
             CONF_FORCE_UPDATE: False,
             CONF_ATTRIBUTES: {
@@ -725,7 +726,7 @@ async def test_restore_replaces_missing_native_unit_from_config_attributes(
             CONF_VARIABLE_ID: "legacy_power",
             CONF_VALUE: 1,
             CONF_VALUE_TYPE: "number",
-            CONF_YAML_VARIABLE: True,
+            CONF_YAML_VARIABLE: False,
             CONF_RESTORE: False,
             CONF_FORCE_UPDATE: False,
             CONF_ATTRIBUTES: {
@@ -796,3 +797,97 @@ async def test_update_sensor_promotes_unit_of_measurement_attribute(
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfPower.KILO_WATT
+
+
+@pytest.mark.parametrize(
+    ("config", "initial_native", "extra_attributes", "expected_native"),
+    [
+        pytest.param(
+            {
+                CONF_VARIABLE_ID: "unit_fill",
+                CONF_VALUE: 1,
+                CONF_DEVICE_CLASS: SensorDeviceClass.POWER,
+                CONF_ATTRIBUTES: {CONF_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT},
+            },
+            None,
+            {CONF_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT},
+            UnitOfPower.KILO_WATT,
+            id="attributes-unit",
+        ),
+        pytest.param(
+            {
+                CONF_VARIABLE_ID: "unit_fill",
+                CONF_VALUE: 1,
+                CONF_ATTRIBUTES: {ATTR_NATIVE_UNIT_OF_MEASUREMENT: UnitOfPower.WATT},
+            },
+            None,
+            {},
+            UnitOfPower.WATT,
+            id="attributes-native-unit",
+        ),
+        pytest.param(
+            {
+                CONF_VARIABLE_ID: "unit_fill",
+                CONF_VALUE: 1,
+                CONF_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT,
+            },
+            None,
+            {},
+            UnitOfPower.KILO_WATT,
+            id="config-unit",
+        ),
+        pytest.param(
+            {
+                CONF_VARIABLE_ID: "unit_fill",
+                CONF_VALUE: 1,
+                CONF_ATTRIBUTES: {CONF_UNIT_OF_MEASUREMENT: "none"},
+            },
+            None,
+            {},
+            None,
+            id="none-string",
+        ),
+        pytest.param(
+            {
+                CONF_VARIABLE_ID: "unit_fill",
+                CONF_VALUE: 1,
+                CONF_ATTRIBUTES: {CONF_UNIT_OF_MEASUREMENT: UnitOfPower.WATT},
+            },
+            UnitOfPower.KILO_WATT,
+            {CONF_UNIT_OF_MEASUREMENT: UnitOfPower.WATT},
+            UnitOfPower.KILO_WATT,
+            id="keep-existing-native",
+        ),
+    ],
+)
+def test_apply_missing_native_unit_from_config(
+    hass: HomeAssistant,
+    config_entry_factory: ConfigEntryFactory,
+    config: dict[str, object],
+    initial_native: str | None,
+    extra_attributes: dict[str, str],
+    expected_native: str | None,
+) -> None:
+    """Fill or preserve native units from configured sensor unit attributes.
+
+    Args:
+        hass (HomeAssistant): Home Assistant test instance.
+        config_entry_factory (ConfigEntryFactory): Factory for test configuration entries.
+        config (dict[str, object]): Variable configuration used to construct the entity.
+        initial_native (str | None): Native unit present before the helper runs.
+        extra_attributes (dict[str, str]): Extra state attributes present before the helper runs.
+        expected_native (str | None): Native unit expected after the helper runs.
+    """
+    entry = config_entry_factory(config)
+    sensor = Variable(hass, dict(entry.data), entry, entry.entry_id)
+    sensor._attr_native_unit_of_measurement = initial_native
+    sensor._attr_extra_state_attributes = dict(extra_attributes)
+
+    sensor._apply_missing_native_unit_from_config()
+
+    assert sensor._attr_native_unit_of_measurement == expected_native
+    extra_state_attributes = sensor._attr_extra_state_attributes
+    assert extra_state_attributes is not None
+    assert CONF_UNIT_OF_MEASUREMENT not in extra_state_attributes
+    if expected_native == UnitOfPower.KILO_WATT and config.get(CONF_DEVICE_CLASS):
+        assert sensor._attr_suggested_unit_of_measurement == UnitOfPower.KILO_WATT

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -30,6 +30,7 @@ from custom_components.variable.const import (
     CONF_ENTITY_PLATFORM,
     CONF_FORCE_UPDATE,
     CONF_RESTORE,
+    CONF_UPDATED,
     CONF_VALUE,
     CONF_VALUE_TYPE,
     CONF_VARIABLE_ID,
@@ -667,6 +668,7 @@ async def test_restore_keeps_native_unit_when_display_unit_differs(
             CONF_VALUE_TYPE: "number",
             CONF_YAML_VARIABLE: False,
             CONF_RESTORE: True,
+            CONF_UPDATED: False,
             CONF_FORCE_UPDATE: False,
             CONF_ATTRIBUTES: {
                 "state_class": SensorStateClass.MEASUREMENT,
@@ -727,7 +729,8 @@ async def test_restore_replaces_missing_native_unit_from_config_attributes(
             CONF_VALUE: 1,
             CONF_VALUE_TYPE: "number",
             CONF_YAML_VARIABLE: False,
-            CONF_RESTORE: False,
+            CONF_RESTORE: True,
+            CONF_UPDATED: False,
             CONF_FORCE_UPDATE: False,
             CONF_ATTRIBUTES: {
                 "state_class": SensorStateClass.MEASUREMENT,
@@ -747,6 +750,66 @@ async def test_restore_replaces_missing_native_unit_from_config_attributes(
     assert extra_attributes is not None
     assert CONF_UNIT_OF_MEASUREMENT not in extra_attributes
     assert NATIVE_UNIT_NONE_WARNING not in caplog.text
+
+
+async def test_restore_prefers_stored_native_unit_over_config(
+    hass: HomeAssistant,
+    config_entry_factory: ConfigEntryFactory,
+) -> None:
+    """Keep a restored native unit when configuration specifies a different unit.
+
+    Args:
+        hass (HomeAssistant): Home Assistant test instance.
+        config_entry_factory (ConfigEntryFactory): Factory for test configuration entries.
+    """
+    entity_id = "sensor.restored_unit_precedence"
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(
+                    entity_id,
+                    "1",
+                    {
+                        CONF_DEVICE_CLASS: SensorDeviceClass.POWER,
+                        "state_class": SensorStateClass.MEASUREMENT,
+                        ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.WATT,
+                    },
+                ),
+                {
+                    "native_value": "1",
+                    "native_unit_of_measurement": UnitOfPower.WATT,
+                },
+            )
+        ],
+    )
+    entry = config_entry_factory(
+        {
+            CONF_ENTITY_PLATFORM: Platform.SENSOR,
+            CONF_VARIABLE_ID: "restored_unit_precedence",
+            CONF_VALUE: 0,
+            CONF_VALUE_TYPE: "number",
+            CONF_YAML_VARIABLE: False,
+            CONF_RESTORE: True,
+            CONF_UPDATED: False,
+            CONF_FORCE_UPDATE: False,
+            CONF_ATTRIBUTES: {
+                "state_class": SensorStateClass.MEASUREMENT,
+                CONF_DEVICE_CLASS: SensorDeviceClass.POWER,
+                CONF_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT,
+            },
+        }
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    sensor = _loaded_sensor(hass, entity_id)
+    assert sensor.native_unit_of_measurement == UnitOfPower.WATT
+    extra_attributes = sensor._attr_extra_state_attributes
+    assert extra_attributes is not None
+    assert CONF_UNIT_OF_MEASUREMENT not in extra_attributes
+    assert ATTR_UNIT_OF_MEASUREMENT not in extra_attributes
 
 
 async def test_update_sensor_promotes_unit_of_measurement_attribute(
@@ -846,6 +909,28 @@ async def test_update_sensor_promotes_unit_of_measurement_attribute(
             {},
             None,
             id="none-string",
+        ),
+        pytest.param(
+            {
+                CONF_VARIABLE_ID: "unit_fill",
+                CONF_VALUE: 1,
+                CONF_ATTRIBUTES: {CONF_UNIT_OF_MEASUREMENT: "unknown"},
+            },
+            None,
+            {},
+            None,
+            id="unknown-string",
+        ),
+        pytest.param(
+            {
+                CONF_VARIABLE_ID: "unit_fill",
+                CONF_VALUE: 1,
+                CONF_ATTRIBUTES: {CONF_UNIT_OF_MEASUREMENT: "unavailable"},
+            },
+            None,
+            {},
+            None,
+            id="unavailable-string",
         ),
         pytest.param(
             {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -25,6 +25,7 @@ from custom_components.variable.const import (
     ATTR_ATTRIBUTES,
     ATTR_NATIVE_UNIT_OF_MEASUREMENT,
     ATTR_REPLACE_ATTRIBUTES,
+    ATTR_SUGGESTED_UNIT_OF_MEASUREMENT,
     ATTR_VALUE_DELTA,
     CONF_ATTRIBUTES,
     CONF_ENTITY_PLATFORM,
@@ -976,3 +977,88 @@ def test_apply_missing_native_unit_from_config(
     assert CONF_UNIT_OF_MEASUREMENT not in extra_state_attributes
     if expected_native == UnitOfPower.KILO_WATT and config.get(CONF_DEVICE_CLASS):
         assert sensor._attr_suggested_unit_of_measurement == UnitOfPower.KILO_WATT
+
+
+@pytest.mark.parametrize(
+    ("unit_payload", "expected_native", "expected_suggested"),
+    [
+        pytest.param(
+            {CONF_UNIT_OF_MEASUREMENT: "unknown"},
+            None,
+            None,
+            id="unknown",
+        ),
+        pytest.param(
+            {CONF_UNIT_OF_MEASUREMENT: "unavailable"},
+            None,
+            None,
+            id="unavailable",
+        ),
+        pytest.param(
+            {CONF_UNIT_OF_MEASUREMENT: "None"},
+            None,
+            None,
+            id="none-selector",
+        ),
+        pytest.param(
+            {ATTR_SUGGESTED_UNIT_OF_MEASUREMENT: "unknown"},
+            None,
+            None,
+            id="suggested-unknown",
+        ),
+        pytest.param(
+            {CONF_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT},
+            UnitOfPower.KILO_WATT,
+            None,
+            id="valid-unit",
+        ),
+    ],
+)
+def test_update_attr_settings_normalizes_unit_sentinels(
+    hass: HomeAssistant,
+    config_entry_factory: ConfigEntryFactory,
+    unit_payload: dict[str, str],
+    expected_native: str | None,
+    expected_suggested: str | None,
+) -> None:
+    """Reject missing unit sentinels from attribute payloads.
+
+    Args:
+        hass (HomeAssistant): Home Assistant test instance.
+        config_entry_factory (ConfigEntryFactory): Factory for test configuration entries.
+        unit_payload (dict[str, str]): Special unit attributes to apply.
+        expected_native (str | None): Native unit expected after normalization.
+        expected_suggested (str | None): Suggested unit expected after normalization.
+    """
+    entry = config_entry_factory({CONF_VARIABLE_ID: "unit_sentinels", CONF_VALUE: 1})
+    sensor = Variable(hass, dict(entry.data), entry, entry.entry_id)
+
+    remaining = sensor._update_attr_settings({**unit_payload, "source": "kept"})
+
+    assert remaining is not None
+    assert remaining["source"] == "kept"
+    assert sensor._attr_native_unit_of_measurement == expected_native
+    assert sensor._attr_suggested_unit_of_measurement == expected_suggested
+
+
+def test_init_normalizes_configured_unit_sentinel(
+    hass: HomeAssistant,
+    config_entry_factory: ConfigEntryFactory,
+) -> None:
+    """Treat the UI None unit selector as a missing native unit.
+
+    Args:
+        hass (HomeAssistant): Home Assistant test instance.
+        config_entry_factory (ConfigEntryFactory): Factory for test configuration entries.
+    """
+    entry = config_entry_factory(
+        {
+            CONF_VARIABLE_ID: "ui_none_unit",
+            CONF_VALUE: 1,
+            CONF_UNIT_OF_MEASUREMENT: "None",
+        }
+    )
+    sensor = Variable(hass, dict(entry.data), entry, entry.entry_id)
+
+    assert sensor._attr_native_unit_of_measurement is None
+    assert sensor._attr_suggested_unit_of_measurement is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #184

YAML sensor variables store `device_class`, `state_class`, and `unit_of_measurement` under `attributes`. The sensor already promoted the first two to native entity properties, but left `unit_of_measurement` as a custom extra attribute. Home Assistant then saw native unit `None` for classes like `power` and logged:

> Entity sensor.* is using native unit of measurement 'None' which is not a valid unit for the device class ('power')

The state UI still looked correct because the custom attribute supplied `kW`.

## Changes

- Map YAML and service `unit_of_measurement` onto `_attr_native_unit_of_measurement`, matching `device_class` and `state_class`.
- Restore stored native unit from last sensor extra data. `RestoreSensor.async_added_to_hass()` does not copy it in current Home Assistant, and re-applying config attributes after empty extras would overwrite a restored unit.
- If restored extra data still has native unit `None` (the previous YAML storage shape), refill the unit from config attributes.
- Normalize `unknown`, `unavailable`, `none`, and empty unit sentinels to `None` on init, attribute updates, restore, and fallback — including suggested units.
- Document the YAML attribute behavior and add a power-sensor example.

## Testing

Local pytest: 211 passed. `prek --all-files` passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a12391a4-29eb-46aa-ad19-a6ac3e396f32?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a12391a4-29eb-46aa-ad19-a6ac3e396f32&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sensor unit handling so configured and restored units are correctly recognized as native sensor properties.
  * Preserved restored units and prevented outdated configuration values from overriding them.
  * Added fallback handling for missing, empty, unknown, or unavailable units.
  * Improved suggested units for convertible sensor types.
  * Reduced warnings for sensors with valid unit information.

* **Documentation**
  * Updated YAML configuration guidance and examples to show native device, state, and unit properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->