### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are provided for the [latest release](https://github.com/Wibias/hass-variables/releases) only.
+
+## Reporting a vulnerability
+
+Do not open a public GitHub issue for security vulnerabilities.
+
+Use [GitHub private vulnerability reporting](https://github.com/Wibias/hass-variables/security/advisories/new) when it is available. Otherwise contact [@wibias](https://github.com/Wibias) privately.
+
+Please include:
+
+- The version you tested
+- A description of the issue and its impact
+- Steps to reproduce
+
+Issues in Home Assistant Core should be reported through [Home Assistant security](https://www.home-assistant.io/security/), not this repository.
+
+This is a volunteer-maintained custom integration. Reports will be acknowledged as soon as possible. Accepted reports get a coordinated fix and disclosure.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `SECURITY.md` so GitHub can show a security policy and reporters know not to file public issues for vulnerabilities.

## Policy

- Security fixes apply to the latest release only.
- Prefer GitHub private vulnerability reporting; otherwise contact `@wibias` privately.
- Home Assistant Core issues go to the HA security process, not this repo.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35e3f27c-fedf-4b00-a86c-2a3ac985b2cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35e3f27c-fedf-4b00-a86c-2a3ac985b2cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

