### PR TITLE
Fix numeric_state failures from quoted sensor values

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Used to update the value or attributes of a Sensor Variable
 | Name                 | Key                                     | Required | Default | Description                                                                           |
 |----------------------|-----------------------------------------|----------|---------|---------------------------------------------------------------------------------------|
 | `Targets`            | `target:`<br />&nbsp;&nbsp;`entity_id:` | `Yes`    |         | The entity_ids of one or more sensor variables to update (ex. `sensor.test_variable`) |
-| `New Value`          | `value`                                 | `No`     |         | Value/state to change the variable to                                                 |
+| `New Value`          | `value`                                 | `No`     |         | Value/state to change the variable to. One matching pair of wrapping quotes is stripped, so quoted templates still store a numeric state usable in `numeric_state` conditions |
 | `New Attributes`     | `attributes`                            | `No`     |         | What to update the attributes to                                                      |
 | `Replace Attributes` | `replace_attributes`                    | `No`     | `False` | Replace or merge current attributes (`False` = merge)                                 |
 

--- a/custom_components/variable/const.py
+++ b/custom_components/variable/const.py
@@ -2,7 +2,7 @@
 
 from homeassistant.const import Platform
 
-VERSION = "3.5.15"
+VERSION = "3.5.16"
 
 PLATFORM_NAME = "Variables+History"
 DOMAIN = "variable"

--- a/custom_components/variable/helpers.py
+++ b/custom_components/variable/helpers.py
@@ -12,6 +12,13 @@ import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
+_WRAPPING_QUOTE_PAIRS: dict[str, str] = {
+    "'": "'",
+    '"': '"',
+    "\u2018": "\u2019",
+    "\u201c": "\u201d",
+}
+
 
 class _AttributePathTypeError(TypeError, ValueError):
     """Report incompatible containers while retaining the legacy ValueError API."""
@@ -61,6 +68,24 @@ def _parse_attribute_path(path: str) -> list[str | int]:
     if buffer:
         tokens.append(buffer)
     return tokens
+
+
+def _unwrap_matching_quotes(value: str) -> str:
+    """Remove one layer of matching wrapping quotes from a string.
+
+    Args:
+        value (str): String that may be wrapped in ASCII or typographic quotes.
+
+    Returns:
+        str: The inner text when the first and last characters are a matching
+            quote pair; otherwise the original string.
+    """
+    if len(value) < 2:
+        return value
+    closing = _WRAPPING_QUOTE_PAIRS.get(value[0])
+    if closing is not None and value[-1] == closing:
+        return value[1:-1]
+    return value
 
 
 def set_nested_attribute(target: MutableMapping[str, Any], path: str, value: Any) -> None:
@@ -325,6 +350,7 @@ def value_to_type(
 
     Args:
         init_val (Any): Initial value supplied by YAML, a service, or a template.
+            One matching pair of wrapping quotes is stripped before conversion.
         dest_type (str | None): Requested Variable value type.
 
     Returns:
@@ -345,7 +371,12 @@ def value_to_type(
     if not isinstance(init_val, (str, int, float, datetime.date, datetime.datetime)):
         init_val = str(init_val)
 
+    # Strip one matching quote layer from UI/YAML values such as "'87'".
     if isinstance(init_val, str):
+        init_val = _unwrap_matching_quotes(init_val)
+        if init_val.lower() in ["", "none", "unknown", "unavailable"]:
+            _LOGGER.debug("[value_to_type] return value: %s, returning None", init_val)
+            return None
         return _string_to_type(init_val, dest_type)
     if isinstance(init_val, (int, float)):
         return _number_to_type(init_val, dest_type)

--- a/custom_components/variable/manifest.json
+++ b/custom_components/variable/manifest.json
@@ -15,5 +15,5 @@
     "requirements": [
         "iso4217>=1.15"
     ],
-    "version": "3.5.15"
+    "version": "3.5.16"
 }

--- a/custom_components/variable/services.yaml
+++ b/custom_components/variable/services.yaml
@@ -8,7 +8,7 @@ update_sensor:
   fields:
     value:
       name: New Value
-      description: "New value to set. If a device class and native unit of measurement is set: 1. This will update the value in the native unit of measurement not necessarily the displayed unit of measurement if they are different. 2. It will give an error if the value is not a supported type for the device class (ex. setting a string for a temperature device class) (optional)"
+      description: "New value to set. One matching pair of wrapping quotes is stripped so quoted templates still store a numeric state. If a device class and native unit of measurement is set: 1. This will update the value in the native unit of measurement not necessarily the displayed unit of measurement if they are different. 2. It will give an error if the value is not a supported type for the device class (ex. setting a string for a temperature device class) (optional)"
       example: 9
       selector:
         text:
@@ -235,7 +235,7 @@ set_variable:
         text:
     value:
       name: New Value
-      description: "New value to set. If a device class and native unit of measurement is set: 1. This will update the value in the native unit of measurement not necessarily the displayed unit of measurement if they are different. 2. It will give an error if the value is not a supported type for the device class (ex. setting a string for a temperature device class) (optional)"
+      description: "New value to set. One matching pair of wrapping quotes is stripped so quoted templates still store a numeric state. If a device class and native unit of measurement is set: 1. This will update the value in the native unit of measurement not necessarily the displayed unit of measurement if they are different. 2. It will give an error if the value is not a supported type for the device class (ex. setting a string for a temperature device class) (optional)"
       example: 9
       selector:
         text:
@@ -269,7 +269,7 @@ set_entity:
           domain: sensor
     value:
       name: New Value
-      description: "New value to set. If a device class and native unit of measurement is set: 1. This will update the value in the native unit of measurement not necessarily the displayed unit of measurement if they are different. 2. It will give an error if the value is not a supported type for the device class (ex. setting a string for a temperature device class) (optional)"
+      description: "New value to set. One matching pair of wrapping quotes is stripped so quoted templates still store a numeric state. If a device class and native unit of measurement is set: 1. This will update the value in the native unit of measurement not necessarily the displayed unit of measurement if they are different. 2. It will give an error if the value is not a supported type for the device class (ex. setting a string for a temperature device class) (optional)"
       example: 9
       selector:
         text:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -293,14 +293,14 @@ def test_value_to_type_converts_wrapper_to_string() -> None:
 def test_value_to_type_converts_strings(
     initial: str,
     destination: str | None,
-    expected: str | float | datetime.date | datetime.datetime,
+    expected: str | int | float | datetime.date | datetime.datetime,
 ) -> None:
     """Convert valid strings to the requested public destination type.
 
     Args:
         initial (str): String value to convert.
         destination (str | None): Requested destination type, or None for the default.
-        expected (str | float | datetime.date | datetime.datetime): Converted value.
+        expected (str | int | float | datetime.date | datetime.datetime): Converted value.
     """
     assert value_to_type(initial, destination) == expected
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -281,6 +281,13 @@ def test_value_to_type_converts_wrapper_to_string() -> None:
         ),
         pytest.param("42", "number", 42, id="integer"),
         pytest.param("4.25", "number", 4.25, id="float"),
+        pytest.param("'87'", "number", 87, id="single-quoted-integer"),
+        pytest.param('"4.25"', "number", 4.25, id="double-quoted-float"),
+        pytest.param("'87'", None, "87", id="single-quoted-default-string"),
+        pytest.param("'87'", "string", "87", id="single-quoted-explicit-string"),
+        pytest.param("\u201887\u2019", "number", 87, id="typographic-single-quoted-integer"),
+        pytest.param("\u201c4.25\u201d", "number", 4.25, id="typographic-double-quoted-float"),
+        pytest.param("'2026-07-24'", "date", datetime.date(2026, 7, 24), id="single-quoted-date"),
     ],
 )
 def test_value_to_type_converts_strings(
@@ -294,6 +301,31 @@ def test_value_to_type_converts_strings(
         initial (str): String value to convert.
         destination (str | None): Requested destination type, or None for the default.
         expected (str | float | datetime.date | datetime.datetime): Converted value.
+    """
+    assert value_to_type(initial, destination) == expected
+
+
+@pytest.mark.parametrize(
+    ("initial", "destination", "expected"),
+    [
+        pytest.param("'hello'", "string", "hello", id="quoted-text"),
+        pytest.param("'87", "string", "'87", id="unmatched-opening-quote"),
+        pytest.param("''", "string", None, id="quoted-empty"),
+        pytest.param("'none'", "number", None, id="quoted-none"),
+        pytest.param("'unknown'", None, None, id="quoted-unknown"),
+    ],
+)
+def test_value_to_type_unwraps_wrapping_quotes(
+    initial: str,
+    destination: str | None,
+    expected: str | None,
+) -> None:
+    """Strip one matching quote layer before converting or treating as empty.
+
+    Args:
+        initial (str): Quoted or partially quoted string value.
+        destination (str | None): Requested destination type, or None for the default.
+        expected (str | None): Converted value after quote unwrapping.
     """
     assert value_to_type(initial, destination) == expected
 
@@ -313,6 +345,12 @@ def test_value_to_type_converts_strings(
             "number",
             "Cannot convert string to number",
             id="invalid-number",
+        ),
+        pytest.param(
+            "87'",
+            "number",
+            "Cannot convert string to number",
+            id="trailing-quote-only",
         ),
         pytest.param("value", "boolean", "Invalid dest_type", id="invalid-destination"),
     ],

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -300,7 +300,7 @@ def test_value_to_type_converts_strings(
     Args:
         initial (str): String value to convert.
         destination (str | None): Requested destination type, or None for the default.
-        expected (str | int | float | datetime.date | datetime.datetime): Converted value.
+        expected (str | float | datetime.date | datetime.datetime): Converted value.
     """
     assert value_to_type(initial, destination) == expected
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -293,7 +293,7 @@ def test_value_to_type_converts_wrapper_to_string() -> None:
 def test_value_to_type_converts_strings(
     initial: str,
     destination: str | None,
-    expected: str | int | float | datetime.date | datetime.datetime,
+    expected: str | float | datetime.date | datetime.datetime,
 ) -> None:
     """Convert valid strings to the requested public destination type.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -514,6 +514,65 @@ async def test_update_sensor_rejects_incompatible_typed_value(
     assert state.state == "2026-08-10"
 
 
+@pytest.mark.parametrize(
+    ("value_type", "entity_id", "variable_id", "quoted_value"),
+    [
+        pytest.param("string", "sensor.quoted_string", "quoted_string", "'87'", id="string"),
+        pytest.param("number", "sensor.quoted_number", "quoted_number", "'87'", id="number"),
+        pytest.param(
+            "string", "sensor.quoted_double", "quoted_double", '"87.5"', id="double-quoted"
+        ),
+    ],
+)
+async def test_update_sensor_unwraps_quoted_numeric_value(
+    hass: HomeAssistant,
+    config_entry_factory: ConfigEntryFactory,
+    value_type: str,
+    entity_id: str,
+    variable_id: str,
+    quoted_value: str,
+) -> None:
+    """Store quoted numeric service values as plain numbers for numeric_state.
+
+    Args:
+        hass (HomeAssistant): Home Assistant test instance.
+        config_entry_factory (ConfigEntryFactory): Factory for test configuration entries.
+        value_type (str): Configured Variable value type.
+        entity_id (str): Entity ID created from the variable id.
+        variable_id (str): Variable ID used to create the config entry.
+        quoted_value (str): Quoted numeric payload as supplied from the UI or YAML.
+    """
+    entry = config_entry_factory(
+        {
+            CONF_ENTITY_PLATFORM: Platform.SENSOR,
+            CONF_VARIABLE_ID: variable_id,
+            CONF_VALUE: None,
+            CONF_VALUE_TYPE: value_type,
+            CONF_YAML_VARIABLE: False,
+            CONF_RESTORE: False,
+            CONF_FORCE_UPDATE: False,
+        }
+    )
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_UPDATE_SENSOR,
+        {
+            "entity_id": [entity_id],
+            CONF_VALUE: quoted_value,
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == quoted_value.strip("\"'")
+    assert "'" not in state.state
+    assert '"' not in state.state
+
+
 async def test_increment_from_none_uses_zero_baseline(
     hass: HomeAssistant,
     config_entry_factory: ConfigEntryFactory,


### PR DESCRIPTION
## Summary

- Strip one matching pair of wrapping quotes from sensor values before type conversion so UI and YAML updates like `'{{ states('sensor.x') }}'` store `87` instead of `'87'`.
- Home Assistant `numeric_state` conditions can then parse the variable state as a number.

## Validation

- `prek run --all-files` — pass
- WSL `uv run pytest` — 230 passed
- `pre-open-gate.mjs` — ready on `c1a2de7017b9ffb2f75f896c686ee1d7b31787fe`

## Review notes

- Unwrapping is one layer only (ASCII and common typographic quotes). Unquoted values are unchanged.

## Limitations

- Entities already restored with quoted states are not rewritten until the next `variable.update_sensor` call.

Fixes #189

<!-- github-delivery:idempotency 6447b7d53dca519b2ffd1b92ac852a6a01da89a1d24abee9ca912278f6ace4e9 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quoted values are automatically unwrapped when updating sensors, variables, and entities.
  * Quoted numeric values are stored as numbers, enabling use with numeric state conditions.
  * Matching ASCII and typographic quotation marks are supported.
  * Empty or null-like quoted values are treated as unavailable rather than stored as text.

* **Documentation**
  * Updated service documentation to describe quoted-value handling and numeric conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->